### PR TITLE
new: Env vars should be applied last, instead of first.

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -15,6 +15,8 @@ pub trait PartialConfig: Default + DeserializeOwned + Sized {
 
     fn default_values(context: &Self::Context) -> Result<Self, ConfigError>;
 
+    fn env_values() -> Result<Self, ConfigError>;
+
     fn extends_from(&self) -> Option<ExtendsFrom>;
 
     fn merge(&mut self, next: Self);

--- a/crates/config/src/internal.rs
+++ b/crates/config/src/internal.rs
@@ -1,24 +1,16 @@
 use crate::error::ConfigError;
 use std::{env, str::FromStr};
 
-pub fn default_from_env_var<T: FromStr>(
-    key: &str,
-    fallback: Option<T>,
-) -> Result<Option<T>, ConfigError> {
-    parse_from_env_var(
-        key,
-        |var| {
-            var.parse::<T>()
-                .map_err(|_| ConfigError::Message("Failed to parse into the correct type.".into()))
-        },
-        fallback,
-    )
+pub fn default_from_env_var<T: FromStr>(key: &str) -> Result<Option<T>, ConfigError> {
+    parse_from_env_var(key, |var| {
+        var.parse::<T>()
+            .map_err(|_| ConfigError::Message("Failed to parse into the correct type.".into()))
+    })
 }
 
 pub fn parse_from_env_var<T>(
     key: &str,
     parser: impl Fn(String) -> Result<T, ConfigError>,
-    fallback: Option<T>,
 ) -> Result<Option<T>, ConfigError> {
     if let Ok(var) = env::var(key) {
         let value =
@@ -27,5 +19,5 @@ pub fn parse_from_env_var<T>(
         return Ok(Some(value));
     }
 
-    Ok(fallback)
+    Ok(None)
 }

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -168,6 +168,9 @@ impl<T: Config> ConfigLoader<T> {
             merged.merge(layer);
         }
 
+        // Last layer should be environment variables
+        merged.merge(T::Partial::env_values()?);
+
         Ok(merged)
     }
 

--- a/crates/config/tests/env_test.rs
+++ b/crates/config/tests/env_test.rs
@@ -90,3 +90,18 @@ fn errors_on_split_parse_fail() {
         .load()
         .unwrap();
 }
+
+#[test]
+#[serial]
+fn env_var_takes_precedence() {
+    reset_vars();
+    env::set_var("ENV_STRING", "foo");
+
+    let result = ConfigLoader::<EnvVars>::new(SourceFormat::Yaml)
+        .code("string: bar")
+        .unwrap()
+        .load()
+        .unwrap();
+
+    assert_eq!(result.config.string, "foo");
+}

--- a/crates/macros/src/config/config.rs
+++ b/crates/macros/src/config/config.rs
@@ -170,6 +170,7 @@ impl<'l> ToTokens for Config<'l> {
         // Generate implementations
         let mut field_names = vec![];
         let mut default_stmts = vec![];
+        let mut env_stmts = vec![];
         let mut from_stmts = vec![];
         let mut merge_stmts = vec![];
         let mut validate_stmts = vec![];
@@ -178,6 +179,7 @@ impl<'l> ToTokens for Config<'l> {
         for setting in &self.settings {
             field_names.push(setting.name);
             default_stmts.push(setting.get_default_statement());
+            env_stmts.push(setting.get_env_statement());
             from_stmts.push(setting.get_from_statement());
             merge_stmts.push(setting.get_merge_statement());
             validate_stmts.push(setting.get_validate_statement());
@@ -191,6 +193,12 @@ impl<'l> ToTokens for Config<'l> {
                 fn default_values(context: &Self::Context) -> Result<Self, schematic::ConfigError> {
                     Ok(Self {
                         #(#field_names: #default_stmts),*
+                    })
+                }
+
+                 fn env_values() -> Result<Self, schematic::ConfigError> {
+                    Ok(Self {
+                        #(#field_names: #env_stmts),*
                     })
                 }
 

--- a/crates/macros/src/config/setting.rs
+++ b/crates/macros/src/config/setting.rs
@@ -116,21 +116,11 @@ impl<'l> Setting<'l> {
     }
 
     pub fn get_default_statement(&self) -> TokenStream {
-        let value = self.value_type.get_default_value(self.name, &self.args);
+        self.value_type.get_default_value(self.name, &self.args)
+    }
 
-        match (&self.args.env, &self.args.parse_env) {
-            (Some(env), Some(parse_env)) => {
-                quote! {
-                    schematic::internal::parse_from_env_var(#env, #parse_env, #value)?
-                }
-            }
-            (Some(env), None) => {
-                quote! {
-                    schematic::internal::default_from_env_var(#env, #value)?
-                }
-            }
-            _ => value,
-        }
+    pub fn get_env_statement(&self) -> TokenStream {
+        self.value_type.get_env_value(&self.args)
     }
 
     pub fn get_from_statement(&self) -> TokenStream {

--- a/crates/macros/src/config/setting_type.rs
+++ b/crates/macros/src/config/setting_type.rs
@@ -149,6 +149,22 @@ impl<'l> SettingType<'l> {
         }
     }
 
+    pub fn get_env_value(&self, args: &SettingArgs) -> TokenStream {
+        match (&args.env, &args.parse_env) {
+            (Some(env), Some(parse_env)) => {
+                quote! {
+                    schematic::internal::parse_from_env_var(#env, #parse_env)?
+                }
+            }
+            (Some(env), None) => {
+                quote! {
+                    schematic::internal::default_from_env_var(#env)?
+                }
+            }
+            _ => quote! { None },
+        }
+    }
+
     pub fn get_from_value(&self, name: &Ident, args: &SettingArgs) -> TokenStream {
         match self {
             SettingType::Nested {


### PR DESCRIPTION
It's the last chance to override a value.