### PR TITLE
fix: Improve error rendering.

### DIFF
--- a/crates/config/src/error.rs
+++ b/crates/config/src/error.rs
@@ -80,7 +80,8 @@ pub enum ConfigError {
     Validator {
         config: String,
 
-        #[diagnostic_source]
+        // This includes the vertical red line which we don't want!
+        // #[diagnostic_source]
         #[source]
         error: ValidatorError,
     },
@@ -110,7 +111,7 @@ impl ConfigError {
             }
             ConfigError::Parser { error: inner, .. } => {
                 push_end();
-                message.push_str(&inner.to_full_string());
+                message.push_str(&inner.to_string());
             }
             ConfigError::Validator { error: inner, .. } => {
                 push_end();
@@ -119,92 +120,21 @@ impl ConfigError {
             _ => {}
         };
 
-        message
+        message.trim().to_string()
     }
 }
 
 #[derive(Error, Debug, Diagnostic)]
-#[error("{}{} {error}\n", .path.style(Style::Id), ":".style(Style::MutedLight))]
+#[error("{}{} {message}\n", .path.style(Style::Id), ":".style(Style::MutedLight))]
 #[diagnostic(severity(Error))]
 pub struct ParserError {
     #[source_code]
     pub content: NamedSource,
 
-    pub error: String,
+    pub message: String,
 
     pub path: String,
 
     #[label("Fix this")]
     pub span: Option<SourceSpan>,
 }
-
-impl ParserError {
-    pub fn to_full_string(&self) -> String {
-        let mut message = self.to_string();
-        message.push_str(".\n");
-        message.push_str(&self.error);
-        message
-    }
-}
-
-// #[derive(Error, Debug, Diagnostic)]
-// pub enum ParserError {
-//     #[cfg(feature = "json")]
-//     #[diagnostic(code(parse::json::failed))]
-//     #[error("Invalid setting {}", .path.style(Style::Id))]
-//     Json {
-//         #[source]
-//         error: serde_json::Error,
-//         path: String,
-//     },
-
-//     #[cfg(feature = "toml")]
-//     #[diagnostic(code(parse::toml::failed))]
-//     #[error("Invalid setting {}", .path.style(Style::Id))]
-//     Toml {
-//         #[source]
-//         error: toml::de::Error,
-//         path: String,
-//     },
-
-//     #[cfg(feature = "yaml")]
-//     #[diagnostic(code(parse::yaml::failed))]
-//     #[error("Invalid setting {}", .path.style(Style::Id))]
-//     Yaml {
-//         #[source]
-//         error: serde_yaml::Error,
-//         path: String,
-//     },
-
-//     #[cfg(feature = "yaml")]
-//     #[diagnostic(code(parse::yaml::extended))]
-//     #[error("Failed to apply YAML anchors and references.")]
-//     YamlExtended {
-//         #[source]
-//         error: serde_yaml::Error,
-//     },
-// }
-
-// impl ParserError {
-//     pub fn to_full_string(&self) -> String {
-//         let mut message = self.to_string();
-//         message.push_str("\n  ");
-
-//         match self {
-//             #[cfg(feature = "json")]
-//             ParserError::Json { error, .. } => {
-//                 message.push_str(&error.to_string());
-//             }
-//             #[cfg(feature = "toml")]
-//             ParserError::Toml { error, .. } => {
-//                 message.push_str(error.message());
-//             }
-//             #[cfg(feature = "yaml")]
-//             ParserError::Yaml { error, .. } | ParserError::YamlExtended { error, .. } => {
-//                 message.push_str(&error.to_string());
-//             }
-//         };
-
-//         message
-//     }
-// }

--- a/crates/config/src/error.rs
+++ b/crates/config/src/error.rs
@@ -79,6 +79,8 @@ pub enum ConfigError {
     #[error("Failed to validate {config}")]
     Validator {
         config: String,
+
+        #[diagnostic_source]
         #[source]
         error: ValidatorError,
     },
@@ -122,7 +124,7 @@ impl ConfigError {
 }
 
 #[derive(Error, Debug, Diagnostic)]
-#[error("Invalid setting {}", .path.style(Style::Id))]
+#[error("{}{} {error}\n", .path.style(Style::Id), ":".style(Style::MutedLight))]
 #[diagnostic(severity(Error))]
 pub struct ParserError {
     #[source_code]
@@ -132,7 +134,7 @@ pub struct ParserError {
 
     pub path: String,
 
-    #[label("{}", .error)]
+    #[label("Fix this")]
     pub span: Option<SourceSpan>,
 }
 

--- a/crates/config/src/source.rs
+++ b/crates/config/src/source.rs
@@ -42,7 +42,7 @@ impl SourceFormat {
                         error.inner().line(),
                         error.inner().column(),
                     )),
-                    error: error.inner().to_string(),
+                    message: error.inner().to_string(),
                 })?
             }
 
@@ -54,7 +54,7 @@ impl SourceFormat {
                     content: NamedSource::new(source, content.to_owned()),
                     path: error.path().to_string(),
                     span: error.inner().span().map(|s| s.into()),
-                    error: error.inner().message().to_owned(),
+                    message: error.inner().message().to_owned(),
                 })?
             }
 
@@ -72,7 +72,7 @@ impl SourceFormat {
                             .inner()
                             .location()
                             .map(|s| create_span(&content, s.line(), s.column())),
-                        error: error.inner().to_string(),
+                        message: error.inner().to_string(),
                     })?;
 
                 // Applies anchors/aliases/references
@@ -80,7 +80,7 @@ impl SourceFormat {
                     content: NamedSource::new(source, content.to_owned()),
                     path: String::new(),
                     span: error.location().map(|s| (s.line(), s.column()).into()),
-                    error: error.to_string(),
+                    message: error.to_string(),
                 })?;
 
                 // Second pass, convert value to struct
@@ -93,7 +93,7 @@ impl SourceFormat {
                         .inner()
                         .location()
                         .map(|s| create_span(&content, s.line(), s.column())),
-                    error: error.inner().to_string(),
+                    message: error.inner().to_string(),
                 })?
             }
         };

--- a/crates/config/src/validate.rs
+++ b/crates/config/src/validate.rs
@@ -151,7 +151,7 @@ pub fn extends_string<D, C>(value: &str, data: &D, context: &C) -> Result<(), Va
 pub fn extends_list<D, C>(values: &[String], data: &D, context: &C) -> Result<(), ValidateError> {
     for (i, value) in values.iter().enumerate() {
         if let Err(mut error) = extends_string(value, data, context) {
-            error.path = Some(SettingPath::new(vec![Segment::Index(i)]));
+            error.path = SettingPath::new(vec![Segment::Index(i)]);
 
             return Err(error);
         }

--- a/crates/config/tests/errors_test.rs
+++ b/crates/config/tests/errors_test.rs
@@ -29,7 +29,7 @@ mod json {
 
         assert_eq!(
             error.to_full_string(),
-            "Failed to parse BaseConfig. Invalid setting setting.\ninvalid type: integer `123`, expected a boolean at line 1 column 16"
+            "Failed to parse BaseConfig. setting: invalid type: integer `123`, expected a boolean at line 1 column 16"
         )
     }
 
@@ -44,7 +44,7 @@ mod json {
 
         assert_eq!(
             error.to_full_string(),
-            "Failed to parse BaseConfig. Invalid setting nested.setting.\ninvalid type: integer `123`, expected a boolean at line 1 column 28"
+            "Failed to parse BaseConfig. nested.setting: invalid type: integer `123`, expected a boolean at line 1 column 28"
         )
     }
 }
@@ -64,7 +64,7 @@ mod toml {
 
         assert_eq!(
             error.to_full_string(),
-            "Failed to parse BaseConfig. Invalid setting setting.\ninvalid type: integer `123`, expected a boolean"
+            "Failed to parse BaseConfig. setting: invalid type: integer `123`, expected a boolean"
         )
     }
 
@@ -79,7 +79,7 @@ mod toml {
 
         assert_eq!(
             error.to_full_string(),
-            "Failed to parse BaseConfig. Invalid setting nested.setting.\ninvalid type: integer `123`, expected a boolean"
+            "Failed to parse BaseConfig. nested.setting: invalid type: integer `123`, expected a boolean"
         )
     }
 }
@@ -99,7 +99,7 @@ mod yaml {
 
         assert_eq!(
             error.to_full_string(),
-            "Failed to parse BaseConfig. Invalid setting setting.\ninvalid type: integer `123`, expected a boolean"
+            "Failed to parse BaseConfig. setting: invalid type: integer `123`, expected a boolean"
         )
     }
 
@@ -114,7 +114,7 @@ mod yaml {
 
         assert_eq!(
             error.to_full_string(),
-            "Failed to parse BaseConfig. Invalid setting nested.setting.\ninvalid type: integer `123`, expected a boolean"
+            "Failed to parse BaseConfig. nested.setting: invalid type: integer `123`, expected a boolean"
         )
     }
 }

--- a/crates/test-app/src/main.rs
+++ b/crates/test-app/src/main.rs
@@ -38,7 +38,7 @@ struct TestConfig {
 fn main() -> Result<()> {
     let config = ConfigLoader::<TestConfig>::json()
         //.code(r#"{ "string": "abc", "other": 123 }"#)?
-        // .code("{\n  \"string\": 123\n}")?
+        .code("{\n  \"string\": 123\n}")?
         .load()?;
 
     dbg!(&config.config.string);

--- a/crates/test-app/src/main.rs
+++ b/crates/test-app/src/main.rs
@@ -37,8 +37,8 @@ struct TestConfig {
 
 fn main() -> Result<()> {
     let config = ConfigLoader::<TestConfig>::json()
-        //.code(r#"{ "string": "abc", "other": 123 }"#)?
-        .code("{\n  \"string\": 123\n}")?
+        // .code(r#"{ "string": "abc", "other": 123 }"#)?
+        // .code("{\n  \"string\": 123\n}")?
         .load()?;
 
     dbg!(&config.config.string);


### PR DESCRIPTION
Primarily for parsing. When there was no source code/span, the "label" was not shown, which was the main error we need to display. This fixes that.

<img width="461" alt="Screenshot 2023-05-26 at 2 53 25 PM" src="https://github.com/moonrepo/schematic/assets/143744/c267d232-4576-455c-b802-9225eaeb18d2">
<img width="692" alt="Screenshot 2023-05-26 at 2 53 38 PM" src="https://github.com/moonrepo/schematic/assets/143744/5ca4551c-60dd-4612-b576-fd3e1e03f25d">
