### PR TITLE
new: Use `enum` type for all unit enums.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+#### 🚀 Updates
+
+- Updated enums with all unit variants to use the `Enum` schema type, instead of the `Union` schema
+  type. Enums that mix and match unit with other variants will to continue to use `Union`, and will
+  respect serde tagging.
+
 #### ⚙️ Internal
 
 - Reworked dependencies and features so that some dependencies only enable when a feature is

--- a/crates/config/src/schema/renderers/json_schema.rs
+++ b/crates/config/src/schema/renderers/json_schema.rs
@@ -137,7 +137,14 @@ impl SchemaRenderer<Schema> for JsonSchemaRenderer {
             };
         }
 
+        let metadata = Metadata {
+            title: enu.name.clone(),
+            description: enu.description.clone().map(clean_comment),
+            ..Default::default()
+        };
+
         Ok(Schema::Object(SchemaObject {
+            metadata: Some(Box::new(metadata)),
             instance_type: Some(SingleOrVec::Single(Box::new(instance_type))),
             enum_values: Some(enum_values),
             ..Default::default()

--- a/crates/config/tests/snapshots/generator_test__json_schema__defaults.snap
+++ b/crates/config/tests/snapshots/generator_test__json_schema__defaults.snap
@@ -177,6 +177,7 @@ expression: "fs::read_to_string(file).unwrap()"
       "additionalProperties": false
     },
     "BasicEnum": {
+      "title": "BasicEnum",
       "type": "string",
       "enum": [
         "foo",

--- a/crates/config/tests/snapshots/macro_enum_test__generates_json_schema.snap
+++ b/crates/config/tests/snapshots/macro_enum_test__generates_json_schema.snap
@@ -157,43 +157,11 @@ expression: "std::fs::read_to_string(file).unwrap()"
     },
     "AllUnit": {
       "title": "AllUnit",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "foo"
-          ],
-          "properties": {
-            "foo": {
-              "const": "foo"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "bar"
-          ],
-          "properties": {
-            "bar": {
-              "const": "bar"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "baz"
-          ],
-          "properties": {
-            "baz": {
-              "const": "baz"
-            }
-          },
-          "additionalProperties": false
-        }
+      "type": "string",
+      "enum": [
+        "foo",
+        "bar",
+        "baz"
       ]
     },
     "AllUnnamed": {
@@ -399,47 +367,6 @@ expression: "std::fs::read_to_string(file).unwrap()"
               ],
               "maxItems": 2,
               "minItems": 2
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "PartialAllUnit": {
-      "title": "PartialAllUnit",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "foo"
-          ],
-          "properties": {
-            "foo": {
-              "const": "foo"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "bar"
-          ],
-          "properties": {
-            "bar": {
-              "const": "bar"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "baz"
-          ],
-          "properties": {
-            "baz": {
-              "const": "baz"
             }
           },
           "additionalProperties": false
@@ -713,48 +640,6 @@ expression: "std::fs::read_to_string(file).unwrap()"
         }
       ]
     },
-    "PartialWithComments": {
-      "title": "PartialWithComments",
-      "description": "Container",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "foo"
-          ],
-          "properties": {
-            "foo": {
-              "const": "foo"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "bar"
-          ],
-          "properties": {
-            "bar": {
-              "const": "bar"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "baz"
-          ],
-          "properties": {
-            "baz": {
-              "const": "baz"
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
     "PartialWithSerde": {
       "title": "PartialWithSerde",
       "anyOf": [
@@ -816,43 +701,11 @@ expression: "std::fs::read_to_string(file).unwrap()"
     "WithComments": {
       "title": "WithComments",
       "description": "Container",
-      "anyOf": [
-        {
-          "type": "object",
-          "required": [
-            "foo"
-          ],
-          "properties": {
-            "foo": {
-              "const": "foo"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "bar"
-          ],
-          "properties": {
-            "bar": {
-              "const": "bar"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "baz"
-          ],
-          "properties": {
-            "baz": {
-              "const": "baz"
-            }
-          },
-          "additionalProperties": false
-        }
+      "type": "string",
+      "enum": [
+        "foo",
+        "bar",
+        "baz"
       ]
     },
     "WithSerde": {

--- a/crates/config/tests/snapshots/macro_enum_test__generates_typescript.snap
+++ b/crates/config/tests/snapshots/macro_enum_test__generates_typescript.snap
@@ -6,13 +6,7 @@ expression: "std::fs::read_to_string(file).unwrap()"
 
 /* eslint-disable */
 
-export type AllUnit = {
-	foo: 'foo';
-} | {
-	bar: 'bar';
-} | {
-	baz: 'baz';
-};
+export type AllUnit = 'foo' | 'bar' | 'baz';
 
 export type AllUnnamed = {
 	foo: string;
@@ -43,13 +37,7 @@ export type NestedConfigs = {
 
 export type WithSerde = string | boolean | number;
 
-export type WithComments = {
-	foo: 'foo';
-} | {
-	bar: 'bar';
-} | {
-	baz: 'baz';
-};
+export type WithComments = 'foo' | 'bar' | 'baz';
 
 export type Untagged = null | boolean | [number, string] | SomeConfig;
 
@@ -77,14 +65,6 @@ export type AdjacentTagged = {
 } | {
 	type: 'qux';
 	content: SomeConfig;
-};
-
-export type PartialAllUnit = {
-	foo: 'foo';
-} | {
-	bar: 'bar';
-} | {
-	baz: 'baz';
 };
 
 export type PartialAllUnnamed = {
@@ -115,14 +95,6 @@ export type PartialNestedConfigs = {
 };
 
 export type PartialWithSerde = string | boolean | number;
-
-export type PartialWithComments = {
-	foo: 'foo';
-} | {
-	bar: 'bar';
-} | {
-	baz: 'baz';
-};
 
 export type PartialUntagged = null | boolean | [number, string] | PartialSomeConfig;
 

--- a/crates/config/tests/snapshots/macros_test__generates_json_schema.snap
+++ b/crates/config/tests/snapshots/macros_test__generates_json_schema.snap
@@ -51,6 +51,7 @@ expression: "std::fs::read_to_string(file).unwrap()"
   "additionalProperties": false,
   "definitions": {
     "Aliased": {
+      "title": "Aliased",
       "type": "string",
       "enum": [
         "foo",
@@ -59,6 +60,7 @@ expression: "std::fs::read_to_string(file).unwrap()"
       ]
     },
     "BasicEnum": {
+      "title": "BasicEnum",
       "type": "string",
       "enum": [
         "foo",
@@ -362,6 +364,7 @@ expression: "std::fs::read_to_string(file).unwrap()"
       "additionalProperties": false
     },
     "OtherEnum": {
+      "title": "OtherEnum",
       "type": "string",
       "enum": [
         "foo",
@@ -751,6 +754,7 @@ expression: "std::fs::read_to_string(file).unwrap()"
       "additionalProperties": false
     },
     "SomeEnum": {
+      "title": "SomeEnum",
       "type": "string",
       "enum": [
         "a",
@@ -759,6 +763,7 @@ expression: "std::fs::read_to_string(file).unwrap()"
       ]
     },
     "Test": {
+      "title": "Test",
       "type": "string",
       "enum": [
         "FOO",

--- a/crates/macros/src/common/variant.rs
+++ b/crates/macros/src/common/variant.rs
@@ -10,6 +10,8 @@ pub enum TaggedFormat {
     External,
     Internal(String),
     Adjacent(String, String),
+    // Special case for unit only enums
+    Unit,
 }
 
 // #[setting()], #[schema()]
@@ -155,6 +157,17 @@ impl<'l> Variant<'l> {
         };
 
         let outer = match tagged_format {
+            TaggedFormat::Unit => {
+                // This returns `SchemaField` while other branches
+                // return `SchemaType`. Be aware of this downstream!
+                quote! {
+                    SchemaField {
+                        name: Some(#name.into()),
+                        type_of: #inner,
+                        ..Default::default()
+                    }
+                }
+            }
             TaggedFormat::Untagged => inner,
             TaggedFormat::External => {
                 quote! {

--- a/crates/macros/src/config_enum/mod.rs
+++ b/crates/macros/src/config_enum/mod.rs
@@ -183,6 +183,7 @@ pub fn macro_impl(item: TokenStream) -> TokenStream {
                     }
 
                     SchemaType::Enum(EnumType {
+                        description: None,
                         name: Some(#meta_name.into()),
                         values,
                         variants: Some(variants),

--- a/crates/types/src/enums.rs
+++ b/crates/types/src/enums.rs
@@ -3,6 +3,7 @@ use crate::SchemaField;
 
 #[derive(Clone, Debug, Default)]
 pub struct EnumType {
+    pub description: Option<String>,
     pub name: Option<String>,
     pub values: Vec<LiteralType>,
     pub variants: Option<Vec<SchemaField>>,


### PR DESCRIPTION
This feels better than using the union type.