### PR TITLE
docs: Fix repository-url.

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -7,7 +7,7 @@ title = "Schematic"
 
 [output.html]
 curly-quotes = true
-git-repository-url = "https://github.com/milesj/schematic"
+git-repository-url = "https://github.com/moonrepo/schematic"
 git-repository-icon = "fa-github"
 
 [output.linkcheck]


### PR DESCRIPTION
![image](https://github.com/moonrepo/schematic/assets/6259812/0942a7d0-b18e-405b-920e-8dbd3f9ac686)

This GitHub repo link was pointing to an old URL.