### PR TITLE
feat: allow adding additional attributes to the partial object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,6 +1926,7 @@ name = "schematic"
 version = "0.18.4"
 dependencies = [
  "chrono",
+ "derive_more",
  "garde",
  "indexmap",
  "markdown",

--- a/book/src/config/partial.md
+++ b/book/src/config/partial.md
@@ -47,3 +47,26 @@ As stated above, partials also handle the following:
 - Merging partials with [strategy functions](./struct/merge.md).
 - Validating current values with [validate functions](./struct/validate.md).
 - Declaring [extendable sources](./struct/extend.md).
+
+## Partial Attribute Forwarding
+
+Attributes can be forwarded to the generated partial struct using the `#[config(partial())]` attribute on structs and enums.
+
+```rust
+#[derive(Config)]
+#[config(partial(derive(derive_more::AsRef))]
+struct ExampleConfig {
+	//
+}
+```
+
+Fields attributes can be forwarded using `#[setting(partial())]`.
+
+```rust
+#[derive(Config)]
+#[config(partial(derive(derive_more::AsRef))]
+struct ExampleConfig {
+	#[setting(partial(as_ref))]
+	port: usize
+}
+```

--- a/crates/macros/src/common/field.rs
+++ b/crates/macros/src/common/field.rs
@@ -1,4 +1,5 @@
 use crate::common::FieldValue;
+use crate::common::PartialAttr;
 use crate::common::macros::ContainerSerdeArgs;
 use crate::utils::{
     extract_comment, extract_common_attrs, extract_deprecated, format_case, map_bool_field_quote,
@@ -55,6 +56,7 @@ pub struct FieldArgs {
     pub transform: Option<ExprPath>,
     #[cfg(feature = "validate")]
     pub validate: Option<Expr>,
+    pub partial: PartialAttr,
 
     // serde
     pub alias: Option<String>,
@@ -337,6 +339,8 @@ impl ToTokens for Field<'_> {
         for attr in &self.attrs {
             attrs.push(quote! { #attr });
         }
+        let partial = &self.args.partial;
+        attrs.push(quote! {#partial});
 
         if let Some(name) = &self.name {
             tokens.extend(quote! {

--- a/crates/schematic/Cargo.toml
+++ b/crates/schematic/Cargo.toml
@@ -134,6 +134,7 @@ reqwest = { workspace = true, features = [
 serial_test = "3.2.0"
 similar = "2.7.0"
 starbase_sandbox = { workspace = true }
+derive_more = { version = "2.0.1", features = ["try_into", "as_ref"] }
 
 # Types
 chrono = { workspace = true, features = ["serde"] }

--- a/crates/schematic/tests/partialize_test.rs
+++ b/crates/schematic/tests/partialize_test.rs
@@ -38,6 +38,7 @@ fn create_diff<T: Schematic>() -> String {
 struct Empty {}
 
 #[derive(Config)]
+#[config(partial(derive(derive_more::AsRef)))]
 struct Basic {
     field: String,
 }
@@ -203,7 +204,10 @@ fn enum_internal() {
 }
 
 #[derive(Config)]
-#[config(serde(tag = "type", content = "content"))]
+#[config(
+    serde(tag = "type", content = "content"),
+    partial(derive(derive_more::TryInto))
+)]
 enum AdjacentTagged {
     Foo,
     Bar(bool),
@@ -215,4 +219,31 @@ enum AdjacentTagged {
 #[test]
 fn enum_adjacent() {
     assert_snapshot!(create_diff::<AdjacentTagged>());
+}
+
+#[derive(Config)]
+#[config(partial(derive(derive_more::AsRef)))]
+struct Basic2 {
+    #[setting(partial(as_ref))]
+    field1: String,
+    field2: String,
+}
+
+#[test]
+fn partial_derive() {
+    // Ensure the attributes we applied to the partial struct were applied correctly
+
+    let bar: bool = PartialAdjacentTagged::Bar(true).try_into().unwrap();
+    assert!(bar);
+
+    let basic = PartialBasic {
+        field: Some("test".to_string()),
+    };
+    assert_eq!(&Some("test".to_string()), basic.as_ref());
+
+    let basic2 = PartialBasic2 {
+        field1: Some("test1".to_string()),
+        field2: Some("test2".to_string()),
+    };
+    assert_eq!(&Some("test1".to_string()), basic2.as_ref());
 }


### PR DESCRIPTION
Resolves #148 

Allows for forwarding additional attributes to the generated partial struct/enum. This is particularly useful for integration with CLI parsing crates like `clap` as you can now create a struct like this:

```rust
#[derive(schematic::Config, Debug)]
#[config(partial(derive(clap::Args)))]
pub struct AppConfig {
    #[setting(default = 3000, partial(arg(long)))]
    port: usize,
    ...
}
```

and reuse your config schema with an argument parser.