### PR TITLE
don't rely on external `serde` crate

### DIFF
--- a/crates/macros/src/config/container.rs
+++ b/crates/macros/src/config/container.rs
@@ -368,12 +368,15 @@ impl Container<'_> {
         partial_name: &Ident,
         partial_attrs: &[TokenStream],
     ) -> TokenStream {
+        let serde = quote! { ::schematic::serde };
+
         match self {
             Self::NamedStruct {
                 fields: settings, ..
             } => {
                 quote! {
-                    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+                    #[derive(Clone, Debug, Default, PartialEq, #serde::Deserialize, #serde::Serialize)]
+                    #[serde(crate = "::schematic::serde")]
                     #(#partial_attrs)*
                     pub struct #partial_name {
                         #(#settings)*
@@ -384,7 +387,8 @@ impl Container<'_> {
                 fields: settings, ..
             } => {
                 quote! {
-                    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+                    #[derive(Clone, Debug, Default, PartialEq, #serde::Deserialize, #serde::Serialize)]
+                    #[serde(crate = "::schematic::serde")]
                     #(#partial_attrs)*
                     pub struct #partial_name(
                         #(#settings)*
@@ -406,7 +410,8 @@ impl Container<'_> {
                 };
 
                 quote! {
-                    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+                    #[derive(Clone, Debug, PartialEq, #serde::Deserialize, #serde::Serialize)]
+                    #[serde(crate = "::schematic::serde")]
                     #(#partial_attrs)*
                     pub enum #partial_name {
                         #(#variants)*

--- a/crates/schematic/src/lib.rs
+++ b/crates/schematic/src/lib.rs
@@ -32,6 +32,9 @@ pub use starbase_styles::color;
 #[cfg(feature = "config")]
 pub use config::*;
 
+#[doc(hidden)]
+pub use ::serde;
+
 pub use format::*;
 pub use schematic_macros::*;
 pub use schematic_types::{Schema, SchemaBuilder, SchemaType, Schematic};


### PR DESCRIPTION
This change ensures that the user doesn't need `serde` in their list of dependencies. This solution breaks if someone renames the `schematic` package to something else, but AFAIK there is no good solution to this?