### PR TITLE
clippy fixes when `schema` feature is disabled

### DIFF
--- a/crates/macros/src/common/container.rs
+++ b/crates/macros/src/common/container.rs
@@ -1,8 +1,6 @@
 use crate::common::{Field, Variant};
-use crate::utils::{extract_comment, extract_deprecated, map_option_argument_quote};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
-use syn::{Attribute, Fields};
 
 pub enum Container<'l> {
     NamedStruct { fields: Vec<Field<'l>> },
@@ -84,7 +82,11 @@ impl Container<'_> {
         }
     }
 
-    pub fn generate_schema(&self, attrs: &[&Attribute]) -> TokenStream {
+    #[cfg(feature = "schema")]
+    pub fn generate_schema(&self, attrs: &[&syn::Attribute]) -> TokenStream {
+        use crate::utils::{extract_comment, extract_deprecated, map_option_argument_quote};
+        use syn::Fields;
+
         let deprecated = if let Some(comment) = extract_deprecated(attrs) {
             quote! { schema.set_deprecated(#comment); }
         } else {

--- a/crates/macros/src/common/field_value.rs
+++ b/crates/macros/src/common/field_value.rs
@@ -190,6 +190,7 @@ impl<'l> FieldValue<'l> {
         }
     }
 
+    #[cfg(feature = "schema")]
     pub fn get_inner_type(&self) -> Option<&'l Type> {
         match self {
             Self::Value { value, .. } => Some(value),

--- a/crates/macros/src/common/macros.rs
+++ b/crates/macros/src/common/macros.rs
@@ -196,6 +196,7 @@ impl<'l> Macro<'l> {
         }
     }
 
+    #[cfg(feature = "schema")]
     pub fn get_name(&self) -> String {
         match &self.args.rename {
             Some(local) => local.to_owned(),

--- a/crates/macros/src/common/variant.rs
+++ b/crates/macros/src/common/variant.rs
@@ -9,7 +9,9 @@ use syn::{Attribute, ExprPath, Fields, Variant as NativeVariant};
 pub enum TaggedFormat {
     Untagged,
     External,
+    #[cfg_attr(not(feature = "schema"), allow(dead_code))]
     Internal(String),
+    #[cfg_attr(not(feature = "schema"), allow(dead_code))]
     Adjacent(String, String),
     // Special case for unit only enums
     Unit,
@@ -65,6 +67,7 @@ impl Variant<'_> {
         self.args.default
     }
 
+    #[cfg(feature = "schema")]
     pub fn is_excluded(&self) -> bool {
         self.args.exclude
     }
@@ -136,6 +139,7 @@ impl Variant<'_> {
         })
     }
 
+    #[cfg(feature = "schema")]
     pub fn generate_schema_type(&self, all_unit: bool) -> TokenStream {
         let name = self.get_name(Some(&self.casing_format));
         let tagged_format = if all_unit {

--- a/crates/macros/src/config/container.rs
+++ b/crates/macros/src/config/container.rs
@@ -422,6 +422,7 @@ impl Container<'_> {
         }
     }
 
+    #[cfg(feature = "schema")]
     pub fn generate_partial_schema(
         &self,
         config_name: &Ident,

--- a/crates/macros/src/config_enum/variant.rs
+++ b/crates/macros/src/config_enum/variant.rs
@@ -18,6 +18,7 @@ pub struct VariantArgs {
 
 pub struct Variant<'l> {
     pub args: VariantArgs,
+    #[cfg_attr(not(feature = "schema"), allow(dead_code))]
     pub default: bool,
     pub serde_args: FieldSerdeArgs,
     pub attrs: Vec<&'l Attribute>,

--- a/crates/macros/src/utils.rs
+++ b/crates/macros/src/utils.rs
@@ -123,6 +123,7 @@ pub fn extract_deprecated(attrs: &[&Attribute]) -> Option<String> {
     None
 }
 
+#[cfg(feature = "schema")]
 pub fn map_bool_field_quote(name: &str, value: bool) -> Option<proc_macro2::TokenStream> {
     if value {
         let id = format_ident!("{}", name);
@@ -169,6 +170,7 @@ pub fn map_option_field_quote<T: ToTokens>(
 //     }
 // }
 
+#[cfg(feature = "schema")]
 pub fn map_option_argument_quote<T: ToTokens>(value: Option<T>) -> proc_macro2::TokenStream {
     match value {
         Some(value) => {

--- a/crates/schematic/src/config/loader.rs
+++ b/crates/schematic/src/config/loader.rs
@@ -239,6 +239,7 @@ impl<T: Config> ConfigLoader<T> {
     fn parse_into_layers(
         &self,
         sources_to_parse: &[Source],
+        #[cfg_attr(not(feature = "schema"), allow(unused_variables))]
         context: &<T::Partial as PartialConfig>::Context,
     ) -> Result<Vec<Layer<T>>, ConfigError> {
         let mut layers: Vec<Layer<T>> = vec![];
@@ -250,7 +251,7 @@ impl<T: Config> ConfigLoader<T> {
                 "Creating layer from source"
             );
 
-            // Parse the source into a parial
+            // Parse the source into a partial
             let partial: T::Partial = {
                 let mut cacher = self.cacher.lock().unwrap();
 


### PR DESCRIPTION
I ran across a bunch of Clippy warnings when the `schema` feature is disabled. This PR fixes those.