### PR TITLE
fix "missing `set_description`" error

### DIFF
--- a/crates/macros/src/common/container.rs
+++ b/crates/macros/src/common/container.rs
@@ -143,10 +143,9 @@ impl Container<'_> {
                     let single_type = &schema_types[0];
 
                     quote! {
-                        let mut schema = #single_type;
                         #deprecated
                         #description
-                        schema
+                        #single_type
                     }
                 } else {
                     quote! {

--- a/crates/macros/src/common/container.rs
+++ b/crates/macros/src/common/container.rs
@@ -143,9 +143,10 @@ impl Container<'_> {
                     let single_type = &schema_types[0];
 
                     quote! {
+                        let mut schema = #single_type;
                         #deprecated
                         #description
-                        #single_type
+                        schema
                     }
                 } else {
                     quote! {

--- a/crates/macros/src/common/field.rs
+++ b/crates/macros/src/common/field.rs
@@ -78,7 +78,7 @@ pub struct Field<'l> {
 }
 
 impl Field<'_> {
-    pub fn from(field: &NativeField) -> Field {
+    pub fn from(field: &NativeField) -> Field<'_> {
         let args = FieldArgs::from_attributes(&field.attrs).unwrap_or_default();
         let serde_args = FieldSerdeArgs::from_attributes(&field.attrs).unwrap_or_default();
 
@@ -340,9 +340,8 @@ impl Field<'_> {
             } else {
                 quote! {
                     {
-                        let mut schema = #inner_schema;
                         #description
-                        schema
+                        #inner_schema
                     }
                 }
             }

--- a/crates/macros/src/common/field.rs
+++ b/crates/macros/src/common/field.rs
@@ -340,8 +340,9 @@ impl Field<'_> {
             } else {
                 quote! {
                     {
+                        let mut schema = #inner_schema;
                         #description
-                        #inner_schema
+                        schema
                     }
                 }
             }

--- a/crates/macros/src/common/variant.rs
+++ b/crates/macros/src/common/variant.rs
@@ -51,7 +51,7 @@ pub struct Variant<'l> {
 }
 
 impl Variant<'_> {
-    pub fn from(var: &NativeVariant) -> Variant {
+    pub fn from(var: &NativeVariant) -> Variant<'_> {
         Variant {
             args: VariantArgs::from_attributes(&var.attrs).unwrap_or_default(),
             serde_args: FieldSerdeArgs::from_attributes(&var.attrs).unwrap_or_default(),

--- a/crates/types/src/schema.rs
+++ b/crates/types/src/schema.rs
@@ -113,7 +113,7 @@ impl Schema {
     /// do nothing, otherwise convert to a union.
     pub fn nullify(&mut self) {
         if self.nullable {
-            // May already be a null union through inferrence
+            // May already be a null union through inference
             return;
         }
 
@@ -166,6 +166,28 @@ impl Schema {
             }
             _ => {}
         };
+    }
+
+    /// Mark this schema as deprecated.
+    pub fn set_deprecated(&mut self, value: impl AsRef<str>) {
+        self.deprecated = Some(value.as_ref().to_owned());
+    }
+
+    /// Add a description for this schema.
+    pub fn set_description(&mut self, value: impl AsRef<str>) {
+        self.description = Some(value.as_ref().to_owned());
+    }
+
+    /// Add a name for this schema.
+    pub fn set_name(&mut self, value: impl AsRef<str>) {
+        let name = value.as_ref();
+
+        self.name = Some(name.to_owned());
+    }
+
+    /// Set the type of schema.
+    pub fn set_type(&mut self, value: SchemaType) {
+        self.ty = value;
     }
 }
 


### PR DESCRIPTION
Given this:

```rust
/// A model ID.
#[derive(Schematic)]
pub struct ModelId(pub String);
```

The old implementation resulted in the following code:

```rust
impl schematic::Schematic for ModelId {
    fn schema_name() -> Option<String> {
        Some("ModelId".into())
    }
    fn build_schema(mut schema: schematic::SchemaBuilder) -> schematic::Schema {
        use schematic::schema::*;
        let mut schema = schema.infer::<String>();
        schema.set_description("A model ID.");
        schema
    }
}
```

But the `set_description` needs to be called on the `SchemaBuilder`, instead of the inferred `Schema` type.

The new implementation generates:

```rust
    fn build_schema(mut schema: schematic::SchemaBuilder) -> schematic::Schema {
        use schematic::schema::*;
        schema.set_description("A model ID.");
        schema.infer::<String>()
    }
```

I don't know if this works for all edge-cases, but this fixes my specific compilation error.