### PR TITLE
support `required` attribute on non-optional fields

### DIFF
--- a/crates/macros/src/common/container.rs
+++ b/crates/macros/src/common/container.rs
@@ -17,6 +17,18 @@ impl Container<'_> {
         }
     }
 
+    pub fn has_non_nullable_required(&self) -> bool {
+        match self {
+            Self::NamedStruct { fields } => {
+                fields.iter().any(|v| !v.is_nullable() && v.is_required())
+            }
+            Self::UnnamedStruct { fields } => {
+                fields.iter().any(|v| !v.is_nullable() && v.is_required())
+            }
+            Self::Enum { variants } => variants.iter().any(|v| v.is_required()),
+        }
+    }
+
     pub fn generate_settings_metadata(&self) -> TokenStream {
         let mut settings = vec![];
 

--- a/crates/macros/src/common/field.rs
+++ b/crates/macros/src/common/field.rs
@@ -102,10 +102,6 @@ impl Field<'_> {
             panic!("Cannot use defaults with `nested` configs.");
         }
 
-        if field.is_required() && !field.is_nullable() {
-            panic!("Cannot use required with non-optional settings.");
-        }
-
         field
     }
 

--- a/crates/macros/src/config/container.rs
+++ b/crates/macros/src/config/container.rs
@@ -328,9 +328,9 @@ impl Container<'_> {
                 }
 
                 quote! {
-                    Self {
+                    Ok(Self {
                         #(#setting_names: #from_partial_values),*
-                    }
+                    })
                 }
             }
             Self::UnnamedStruct {
@@ -343,9 +343,9 @@ impl Container<'_> {
                 }
 
                 quote! {
-                    Self(
+                    Ok(Self(
                         #(#from_partial_values),*
-                    )
+                    ))
                 }
             }
             Self::Enum { variants } => {
@@ -355,9 +355,9 @@ impl Container<'_> {
                     .collect::<Vec<_>>();
 
                 quote! {
-                    match partial {
+                    Ok(match partial {
                         #(#from_partial_values)*
-                    }
+                    })
                 }
             }
         }

--- a/crates/macros/src/config/field_value.rs
+++ b/crates/macros/src/config/field_value.rs
@@ -4,10 +4,15 @@ use quote::{format_ident, quote};
 use syn::{Expr, Lit};
 
 impl FieldValue<'_> {
-    pub fn generate_default_value(&self, args: &FieldArgs, nullable: bool) -> TokenStream {
+    pub fn generate_default_value(
+        &self,
+        args: &FieldArgs,
+        nullable: bool,
+        required: bool,
+    ) -> TokenStream {
         match self {
             Self::NestedList { .. } | Self::NestedMap { .. } => {
-                if nullable {
+                if nullable || required {
                     quote! { None }
                 } else {
                     quote! { Some(Default::default()) }
@@ -45,7 +50,7 @@ impl FieldValue<'_> {
                     }
                 },
                 _ => {
-                    if nullable {
+                    if nullable || required {
                         quote! { None }
                     } else {
                         quote! { Some(Default::default()) }
@@ -93,7 +98,7 @@ impl FieldValue<'_> {
                 item, item_info, ..
             } => self.map_data_with_info(
                 quote! {
-                    #item::from_partial(value)
+                    #item::from_partial(value)?
                 },
                 item_info,
             ),
@@ -101,7 +106,7 @@ impl FieldValue<'_> {
                 value, value_info, ..
             } => self.map_data_with_info(
                 quote! {
-                    #value::from_partial(value)
+                    #value::from_partial(value)?
                 },
                 value_info,
             ),
@@ -109,7 +114,7 @@ impl FieldValue<'_> {
                 let config = info.config.as_ref();
 
                 quote! {
-                    #config::from_partial(data)
+                    #config::from_partial(data)?
                 }
             }
             Self::Value { .. } => quote! { data },

--- a/crates/macros/src/config/mod.rs
+++ b/crates/macros/src/config/mod.rs
@@ -32,6 +32,8 @@ impl ToTokens for ConfigMacro<'_> {
         let settings_metadata = cfg.type_of.generate_settings_metadata();
         let instrument = instrument_quote();
 
+        let is_any_required_and_non_nullable = cfg.type_of.has_non_nullable_required();
+
         let context = match cfg.args.context.as_ref() {
             Some(ctx) => quote! { #ctx },
             None => quote! { () },
@@ -124,23 +126,11 @@ impl ToTokens for ConfigMacro<'_> {
             }
 
             #[automatically_derived]
-            impl Default for #name {
-                #instrument
-                fn default() -> Self {
-                    let context = <<Self as schematic::Config>::Partial as schematic::PartialConfig>::Context::default();
-
-                    let defaults = <<Self as schematic::Config>::Partial as schematic::PartialConfig>::default_values(&context).unwrap().unwrap_or_default();
-
-                    <Self as schematic::Config>::from_partial(defaults)
-                }
-            }
-
-            #[automatically_derived]
             impl schematic::Config for #name {
                 type Partial = #partial_name;
 
                 #instrument
-                fn from_partial(partial: Self::Partial) -> Self {
+                fn from_partial(partial: Self::Partial) -> std::result::Result<Self, schematic::ConfigError> {
                     #from_partial
                 }
 
@@ -150,6 +140,23 @@ impl ToTokens for ConfigMacro<'_> {
                 }
             }
         });
+
+        if !is_any_required_and_non_nullable {
+            tokens.extend(quote! {
+                #[automatically_derived]
+                impl Default for #name {
+                    #instrument
+                    fn default() -> Self {
+                        let context = <<Self as schematic::Config>::Partial as schematic::PartialConfig>::Context::default();
+
+                        let defaults = <<Self as schematic::Config>::Partial as schematic::PartialConfig>::default_values(&context).unwrap().unwrap_or_default();
+
+                        <Self as schematic::Config>::from_partial(defaults)
+                            .expect("any partial with missing required values will not derive Default")
+                    }
+                }
+            });
+        }
 
         #[cfg(feature = "schema")]
         {

--- a/crates/macros/src/config/variant.rs
+++ b/crates/macros/src/config/variant.rs
@@ -222,7 +222,7 @@ impl Variant<'_> {
                             if self.is_nested() {
                                 let ty = &fields.unnamed[index].ty;
 
-                                quote! { #ty::from_partial(#o) }
+                                quote! { #ty::from_partial(#o)? }
                             } else {
                                 quote! { #o }
                             }

--- a/crates/schematic/src/config/configs.rs
+++ b/crates/schematic/src/config/configs.rs
@@ -83,7 +83,12 @@ pub trait Config: Sized + Schematic {
     type Partial: PartialConfig;
 
     /// Convert a partial configuration into a full configuration, with all values populated.
-    fn from_partial(partial: Self::Partial) -> Self;
+    ///
+    /// # Errors
+    ///
+    /// If the partial configuration is missing required values, an error is
+    /// returned.
+    fn from_partial(partial: Self::Partial) -> Result<Self, ConfigError>;
 
     /// Return a map of all settings and their metadata for the configuration.
     fn settings() -> ConfigSettingMap {

--- a/crates/schematic/src/config/error.rs
+++ b/crates/schematic/src/config/error.rs
@@ -49,6 +49,10 @@ pub enum ConfigError {
     #[error("Invalid default value. {0}")]
     InvalidDefaultValue(String),
 
+    #[diagnostic(code(config::required))]
+    #[error("Missing required value. {0}")]
+    MissingRequired(String),
+
     #[diagnostic(code(config::file::invalid))]
     #[error("Invalid file path used as a source.")]
     InvalidFile,

--- a/crates/schematic/src/config/loader.rs
+++ b/crates/schematic/src/config/loader.rs
@@ -112,7 +112,7 @@ impl<T: Config> ConfigLoader<T> {
         }
 
         Ok(ConfigLoadResult {
-            config: T::from_partial(partial),
+            config: T::from_partial(partial)?,
             layers,
         })
     }

--- a/crates/schematic/src/config/mod.rs
+++ b/crates/schematic/src/config/mod.rs
@@ -24,6 +24,7 @@ pub use loader::*;
 pub use merger::*;
 pub use parser::*;
 pub use path::*;
+#[cfg(any(feature = "type_regex", feature = "type_semver"))]
 pub use settings::*;
 pub use source::*;
 #[cfg(feature = "validate")]


### PR DESCRIPTION
This is a rough draft, that is probably incomplete, but does compile on my end (I haven't tested it at runtime yet). I wanted to see how invasive it was to support `required` non-optional fields.

Turns out, somewhat invasive, but doable, specifically for the fallout of making `from_partial` fallible.

This isn't ready to merge, so feel free to close if you have no desire to support this. But if you do, I'll continue working on this until it works for my use-case, after which I can add tests to validate correctness.

See also: https://github.com/moonrepo/schematic/issues/99#issuecomment-3139966133