### PR TITLE
use `Display` impl for enum fallback type

### DIFF
--- a/crates/macros/src/config_enum/variant.rs
+++ b/crates/macros/src/config_enum/variant.rs
@@ -80,7 +80,7 @@ impl Variant<'_> {
 
         if self.args.fallback {
             quote! {
-                Self::#name(fallback) => fallback,
+                Self::#name(fallback) => return std::write!(f, "{fallback}"),
             }
         } else {
             quote! {


### PR DESCRIPTION
The docs mention supporting non-String types for the enum fallback value, but the implementation errors when doing so, because of the `Display` impl expecting the fallback variant to return a `&str`. This change allows you to use any type, as long as it implements `Display` itself. This is a non-breaking change.