### PR TITLE
feat: Add API docs renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added an `ApiDocsRenderer`, behind the `renderer_api_docs` feature, that renders a markdown API
   documentation page for a type. Each property or variant is described with tags, its comment, and
   a table of type information, and types referenced from the page are linked to their own pages.
+  The `render_tags` and `render_description` options take functions that customize how tags and
+  descriptions are rendered.
 - Added `UnionType.variants_names`, which a union derived from an enum fills with the name of each
   variant, by position in `variants_types`. Read it through `UnionType::get_variant_name()`.
 - Re-adding a type to `SchemaGenerator` now moves it to the end, so that a type nested by an earlier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added an `ApiDocsRenderer`, behind the `renderer_api_docs` feature, that renders a markdown API
   documentation page for a type. Each property or variant is described with tags, its comment, and
   a table of type information, and types referenced from the page are linked to their own pages.
+- Added `UnionType.variants_names`, which a union derived from an enum fills with the name of each
+  variant, by position in `variants_types`. Read it through `UnionType::get_variant_name()`.
 - Re-adding a type to `SchemaGenerator` now moves it to the end, so that a type nested by an earlier
   one can still become the root of a single-document render.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Added an `ApiDocsRenderer`, behind the `renderer_api_docs` feature, that renders a markdown API
+  documentation page for a type. Each property or variant is described with tags, its comment, and
+  a table of type information, and types referenced from the page are linked to their own pages.
+- Re-adding a type to `SchemaGenerator` now moves it to the end, so that a type nested by an earlier
+  one can still become the root of a single-document render.
+
 ## 0.20.3
 
 #### ⚙️ Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   described with tags, its comment, and a table of type information, and types referenced from the
   page are linked to their own pages.
   The `render_tags` and `render_description` options take functions that customize how tags and
-  descriptions are rendered.
+  descriptions are rendered, and `frontmatter` adds entries to each page's frontmatter.
 - Added `UnionType.variants_names`, which a union derived from an enum fills with the name of each
   variant, by position in `variants_types`. Read it through `UnionType::get_variant_name()`.
 - Re-adding a type to `SchemaGenerator` now moves it to the end, so that a type nested by an earlier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
   described with tags, its comment, and a table of type information, and types referenced from the
   page are linked to their own pages.
   The `render_tags` and `render_description` options take functions that customize how tags and
-  descriptions are rendered, and `frontmatter` adds entries to each page's frontmatter.
+  descriptions are rendered, `frontmatter` adds entries to each page's frontmatter, and
+  `enum_format` can render a unit enum's variants as one table.
 - Added `UnionType.variants_names`, which a union derived from an enum fills with the name of each
   variant, by position in `variants_types`. Read it through `UnionType::get_variant_name()`.
 - Re-adding a type to `SchemaGenerator` now moves it to the end, so that a type nested by an earlier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
   documentation page for a type. An index summarizes every property or variant, each is then
   described with tags, its comment, and a table of type information, and types referenced from the
   page are linked to their own pages.
-  The `render_tags` and `render_description` options take functions that customize how tags and
-  descriptions are rendered, `frontmatter` adds entries to each page's frontmatter, and
+  The `render_tags`, `render_description`, and `render_link` options take functions that customize
+  how tags, descriptions, and links are rendered, `frontmatter` adds entries to each page's frontmatter, and
   `enum_format` can render a unit enum's variants as one table.
 - Added `UnionType.variants_names`, which a union derived from an enum fills with the name of each
   variant, by position in `variants_types`. Read it through `UnionType::get_variant_name()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 #### 🚀 Updates
 
 - Added an `ApiDocsRenderer`, behind the `renderer_api_docs` feature, that renders a markdown API
-  documentation page for a type. Each property or variant is described with tags, its comment, and
-  a table of type information, and types referenced from the page are linked to their own pages.
+  documentation page for a type. An index summarizes every property or variant, each is then
+  described with tags, its comment, and a table of type information, and types referenced from the
+  page are linked to their own pages.
   The `render_tags` and `render_description` options take functions that customize how tags and
   descriptions are rendered.
 - Added `UnionType.variants_names`, which a union derived from an enum fills with the name of each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
   page are linked to their own pages.
   The `render_tags`, `render_description`, and `render_link` options take functions that customize
   how tags, descriptions, and links are rendered, `frontmatter` adds entries to each page's frontmatter, and
-  `enum_format` can render a unit enum's variants as one table.
+  `enum_format` can render a unit enum's variants as one table. `ApiDocsRenderer::generate_all`
+  writes a page for every type in a generator into a directory, along with an index page.
 - Added `UnionType.variants_names`, which a union derived from an enum fills with the name of each
   variant, by position in `variants_types`. Read it through `UnionType::get_variant_name()`.
 - Re-adding a type to `SchemaGenerator` now moves it to the end, so that a type nested by an earlier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
   documentation page for a type. An index summarizes every property or variant, each is then
   described with tags, its comment, and a table of type information, and types referenced from the
   page are linked to their own pages.
-  The `render_tags`, `render_description`, and `render_link` options take functions that customize
-  how tags, descriptions, and links are rendered, `frontmatter` adds entries to each page's frontmatter, and
+  The `render_tags`, `render_description`, `render_link`, and `render_anchor` options take
+  functions that customize how tags, descriptions, links, and section fragments are rendered, `frontmatter` adds entries to each page's frontmatter, and
   `enum_format` can render a unit enum's variants as one table. `ApiDocsRenderer::generate_all`
   writes a page for every type in a generator into a directory, along with an index page.
 - Added `UnionType.variants_names`, which a union derived from an enum fills with the name of each

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -35,7 +35,7 @@
     - [Unknown](./schema/unknown.md)
   - [External types](./schema/external.md)
   - [Code generation](./schema/generator/index.md)
-    - [API documentation]()
+    - [API documentation](./schema/generator/api-docs.md)
     - [Config templates](./schema/generator/template.md)
     - [JSON schemas](./schema/generator/json-schema.md)
     - [TypeScript types](./schema/generator/typescript.md)

--- a/book/src/schema/generator/api-docs.md
+++ b/book/src/schema/generator/api-docs.md
@@ -131,6 +131,49 @@ ApiDocsOptions {
 }
 ```
 
+### Custom tags
+
+Tags are rendered by the `render_tags` function, which receives the tags of a type, property, or
+variant as a list of
+[`ApiDocsTag`](https://docs.rs/schematic/latest/schematic/schema/api_docs/enum.ApiDocsTag.html)
+values, and returns markdown. The default renders a block quote of bold labels, but a documentation
+site may prefer its own components.
+
+```rust
+use schematic::schema::ApiDocsTag;
+
+ApiDocsOptions {
+	// ...
+	render_tags: Box::new(|tags| {
+		tags.iter()
+			.map(|tag| match tag {
+				ApiDocsTag::Deprecated(Some(message)) => format!("<Badge>{tag}</Badge> {message}"),
+				_ => format!("<Badge>{tag}</Badge>"),
+			})
+			.collect::<Vec<_>>()
+			.join(" ")
+	}),
+}
+```
+
+The function is only called when there is at least one tag, and returning an empty string omits the
+tags entirely.
+
+### Custom descriptions
+
+Descriptions are rendered by the `render_description` function, which receives the doc comment as
+written and returns markdown. The default keeps the comment as is, only trimming each line. Use this
+to wrap descriptions in a component, or to rewrite links.
+
+```rust
+ApiDocsOptions {
+	// ...
+	render_description: Box::new(|description| format!(":::note\n{}\n:::", description.trim())),
+}
+```
+
+Returning an empty string omits the description.
+
 ### Aliases
 
 A field's aliases are listed in its table. Disable this with the `exclude_aliases` option.

--- a/book/src/schema/generator/api-docs.md
+++ b/book/src/schema/generator/api-docs.md
@@ -23,7 +23,9 @@ generator.generate(output_dir.join("CustomType.md"), ApiDocsRenderer::default())
 
 Like a [JSON schema](./json-schema.md), each render produces a single document, and the _last type
 to be added to `SchemaGenerator`_ is the one rendered. Every other type in the generator is known to
-the renderer, so a property whose type is one of them links to that type's page.
+the renderer, so a property whose type is one of them links to that type's page. A composite type,
+such as a list of a config, is rendered as code, which cannot hold a link, so the types it refers to
+are linked in a references row of their own.
 
 To generate a page for every type at once, including the ones that were added by nesting, use
 [`ApiDocsRenderer::generate_all()`](https://docs.rs/schematic/latest/schematic/schema/api_docs/struct.ApiDocsRenderer.html#method.generate_all)

--- a/book/src/schema/generator/api-docs.md
+++ b/book/src/schema/generator/api-docs.md
@@ -25,12 +25,23 @@ Like a [JSON schema](./json-schema.md), each render produces a single document, 
 to be added to `SchemaGenerator`_ is the one rendered. Every other type in the generator is known to
 the renderer, so a property whose type is one of them links to that type's page.
 
-Adding a type that is already in the generator, because an earlier type nested it, moves it to the
-end. To generate a page for every type, add each one before generating its file.
+To generate a page for every type at once, including the ones that were added by nesting, use
+[`ApiDocsRenderer::generate_all()`](https://docs.rs/schematic/latest/schematic/schema/api_docs/struct.ApiDocsRenderer.html#method.generate_all)
+with an output directory instead. It writes a page per type, named after the type with a `.md`
+extension, along with an [index page](#index-page).
 
 ```rust
 let mut generator = SchemaGenerator::default();
+generator.add::<RootConfig>();
 
+ApiDocsRenderer::default().generate_all(&generator, output_dir.join("config"))?;
+```
+
+To control each page individually, generate them one at a time. Adding a type that is already in
+the generator, because an earlier type nested it, moves it to the end, so add each one before
+generating its file.
+
+```rust
 generator.add::<RootConfig>();
 generator.generate(output_dir.join("RootConfig.md"), ApiDocsRenderer::default())?;
 
@@ -40,7 +51,38 @@ generator.generate(output_dir.join("NestedConfig.md"), ApiDocsRenderer::default(
 ```
 
 By default links are relative, so all pages are expected to live in the same directory, and to be
-named after the type they document. The [`render_link`](#custom-links) option changes that.
+named after the type they document, which is what `generate_all` produces. The
+[`render_link`](#custom-links) option changes that, and a custom link should agree with wherever
+the pages are written.
+
+## Index page
+
+`generate_all` also writes an index page, a table of every type that links to its page, with its
+kind and the first paragraph of its description.
+
+```markdown
+---
+title: Index
+---
+
+## Types
+
+| Type | Kind | Description |
+| --- | --- | --- |
+| [`ServerConfig`](./ServerConfig.md) | Struct | Configures the HTTP server. |
+| [`TlsConfig`](./TlsConfig.md) | Struct | TLS settings, when serving over HTTPS. |
+```
+
+The `index_page` option names the file, and `None` skips it. When generating pages one at a time,
+[`ApiDocsRenderer::render_index_page()`](https://docs.rs/schematic/latest/schematic/schema/api_docs/struct.ApiDocsRenderer.html#method.render_index_page)
+renders the same content from the generator's schemas.
+
+```rust
+ApiDocsOptions {
+	// ...
+	index_page: Some("README.md".into()),
+}
+```
 
 ## Page structure
 

--- a/book/src/schema/generator/api-docs.md
+++ b/book/src/schema/generator/api-docs.md
@@ -39,8 +39,8 @@ generator.add::<NestedConfig>();
 generator.generate(output_dir.join("NestedConfig.md"), ApiDocsRenderer::default())?;
 ```
 
-Links are relative, so all pages are expected to live in the same directory, and to be named after
-the type they document.
+By default links are relative, so all pages are expected to live in the same directory, and to be
+named after the type they document. The [`render_link`](#custom-links) option changes that.
 
 ## Page structure
 
@@ -91,7 +91,7 @@ TLS settings, when serving over HTTPS.
 
 ## References
 
-- [TlsConfig](./TlsConfig.md)
+- [`TlsConfig`](./TlsConfig.md)
 ```
 
 The tags after a name describe how a property may be provided: whether it is required or optional,
@@ -136,15 +136,19 @@ ApiDocsOptions {
 
 The renderer is created for each page, so per-type values can be set when generating that type.
 
-### Link extension
+### Custom links
 
-Links to other pages append `.md` to the type name. Documentation tools that route on the file name
-rather than the file may want bare links instead, which the `link_extension` option controls.
+Links to other pages are rendered by the `render_link` function, which receives the name of the
+referenced type and returns the whole link, label included. The default labels the link with the
+name as inline code and links to a markdown file named after the type in the same directory, such
+as `` [`Name`](./Name.md) ``. Documentation tools that route on a path rather than a file, pages
+split across directories, or a site with its own link component can return whatever they need. The
+same function renders the inline links and the references list.
 
 ```rust
 ApiDocsOptions {
 	// ...
-	link_extension: "".into(),
+	render_link: Box::new(|name| format!("<Link to=\"/docs/config/{name}\">{name}</Link>")),
 }
 ```
 

--- a/book/src/schema/generator/api-docs.md
+++ b/book/src/schema/generator/api-docs.md
@@ -44,7 +44,7 @@ the type they document.
 
 ## Page structure
 
-A page starts with front matter that titles it after the type, followed by the type's description,
+A page starts with frontmatter that titles it after the type, followed by the type's description,
 and an index that summarizes every section to come, linking to each. A struct then lists its
 properties, and an enum lists its variants, headed by the variant name. A union that was built by
 hand has no variant names, so each of its variants is headed by its type instead. Types that are
@@ -59,10 +59,10 @@ Configures the HTTP server.
 
 ## Index
 
-| Property | Type | Description |
-| --- | --- | --- |
-| [`port`](#port) | `number` | The port to listen on. |
-| [`tls`](#tls) | [`TlsConfig`](./TlsConfig.md) | TLS settings, when serving over HTTPS. |
+| Property        | Type                          | Description                            |
+| --------------- | ----------------------------- | -------------------------------------- |
+| [`port`](#port) | `number`                      | The port to listen on.                 |
+| [`tls`](#tls)   | [`TlsConfig`](./TlsConfig.md) | TLS settings, when serving over HTTPS. |
 
 ## Properties
 
@@ -72,11 +72,11 @@ Configures the HTTP server.
 
 The port to listen on.
 
-| Attribute | Value |
-| --- | --- |
-| Type | `number` |
-| Default | `8080` |
-| Minimum | `1024` |
+| Attribute            | Value         |
+| -------------------- | ------------- |
+| Type                 | `number`      |
+| Default              | `8080`        |
+| Minimum              | `1024`        |
 | Environment variable | `SERVER_PORT` |
 
 ### `tls`
@@ -85,9 +85,9 @@ The port to listen on.
 
 TLS settings, when serving over HTTPS.
 
-| Attribute | Value |
-| --- | --- |
-| Type | [`TlsConfig`](./TlsConfig.md) |
+| Attribute | Value                         |
+| --------- | ----------------------------- |
+| Type      | [`TlsConfig`](./TlsConfig.md) |
 
 ## References
 
@@ -114,6 +114,27 @@ ApiDocsRenderer::new(ApiDocsOptions {
 	..ApiDocsOptions::default()
 });
 ```
+
+### Frontmatter
+
+Each page opens with frontmatter that titles it after the type. Documentation tools often read more
+from it, such as a sidebar position or a label, which the `frontmatter` map adds as `key: value`
+lines after the title, in key order. Values are written verbatim, so quote them as the tool expects.
+A `title` entry replaces the type name.
+
+```rust
+use std::collections::BTreeMap;
+
+ApiDocsOptions {
+	// ...
+	frontmatter: BTreeMap::from_iter([
+		("sidebar_position".into(), "2".into()),
+		("description".into(), "\"Configures the server.\"".into()),
+	]),
+}
+```
+
+The renderer is created for each page, so per-type values can be set when generating that type.
 
 ### Link extension
 

--- a/book/src/schema/generator/api-docs.md
+++ b/book/src/schema/generator/api-docs.md
@@ -44,10 +44,11 @@ the type they document.
 
 ## Page structure
 
-A page starts with front matter that titles it after the type, followed by the type's description.
-A struct then lists its properties, and an enum lists its variants, headed by the variant name. A
-union that was built by hand has no variant names, so each of its variants is headed by its type
-instead. Types that are referenced from the page are listed at the end.
+A page starts with front matter that titles it after the type, followed by the type's description,
+and an index that summarizes every section to come, linking to each. A struct then lists its
+properties, and an enum lists its variants, headed by the variant name. A union that was built by
+hand has no variant names, so each of its variants is headed by its type instead. Types that are
+referenced from the page are listed at the end.
 
 ```markdown
 ---
@@ -55,6 +56,13 @@ title: ServerConfig
 ---
 
 Configures the HTTP server.
+
+## Index
+
+| Property | Type | Description |
+| --- | --- | --- |
+| [`port`](#port) | `number` | The port to listen on. |
+| [`tls`](#tls) | [`TlsConfig`](./TlsConfig.md) | TLS settings, when serving over HTTPS. |
 
 ## Properties
 
@@ -116,6 +124,18 @@ rather than the file may want bare links instead, which the `link_extension` opt
 ApiDocsOptions {
 	// ...
 	link_extension: "".into(),
+}
+```
+
+### Index
+
+The index ahead of the properties or variants shows each one's type and the first paragraph of its
+description. Disable it with the `include_index` option.
+
+```rust
+ApiDocsOptions {
+	// ...
+	include_index: false,
 }
 ```
 

--- a/book/src/schema/generator/api-docs.md
+++ b/book/src/schema/generator/api-docs.md
@@ -148,6 +148,36 @@ ApiDocsOptions {
 }
 ```
 
+### Enum format
+
+A unit enum renders a section per variant, which is thorough but long for an enum with many
+variants. The `enum_format` option can render them as a single table instead, one row per variant
+with its value, tags, and description. The index is omitted for it, as the table already summarizes
+every variant. Unions always render as sections, since their variants carry values that need
+describing.
+
+```rust
+use schematic::schema::ApiDocsEnumFormat;
+
+ApiDocsOptions {
+	// ...
+	enum_format: ApiDocsEnumFormat::Table,
+}
+```
+
+```markdown
+## Variants
+
+| Variant | Value     | Tags                                 | Description            |
+| ------- | --------- | ------------------------------------ | ---------------------- |
+| `debug` | `"debug"` |                                      | Log everything.        |
+| `info`  | `"info"`  | **Default**                          | Log at info and above. |
+| `off`   | `"off"`   | **Deprecated** (Use `none` instead.) | Disable logging.       |
+```
+
+> Tags in the table are rendered as labels, not through the `render_tags` function, as its output is
+> a block that cannot sit inside a table cell.
+
 ### Index
 
 The index ahead of the properties or variants shows each one's type and the first paragraph of its

--- a/book/src/schema/generator/api-docs.md
+++ b/book/src/schema/generator/api-docs.md
@@ -1,0 +1,142 @@
+# API documentation
+
+> Requires the `renderer_api_docs` Cargo feature.
+
+With our
+[`ApiDocsRenderer`](https://docs.rs/schematic/latest/schematic/schema/api_docs/struct.ApiDocsRenderer.html),
+you can generate markdown API documentation for all types that implement
+[`Schematic`](https://docs.rs/schematic/latest/schematic/schema/trait.Schematic.html). Each type
+becomes its own page, describing every property or variant, and linking to the pages of the types it
+references.
+
+To utilize, instantiate a generator, add types to render, and generate the output file.
+
+```rust
+use schematic::schema::{SchemaGenerator, ApiDocsRenderer};
+
+let mut generator = SchemaGenerator::default();
+generator.add::<CustomType>();
+generator.generate(output_dir.join("CustomType.md"), ApiDocsRenderer::default())?;
+```
+
+## One page per type
+
+Like a [JSON schema](./json-schema.md), each render produces a single document, and the _last type
+to be added to `SchemaGenerator`_ is the one rendered. Every other type in the generator is known to
+the renderer, so a property whose type is one of them links to that type's page.
+
+Adding a type that is already in the generator, because an earlier type nested it, moves it to the
+end. To generate a page for every type, add each one before generating its file.
+
+```rust
+let mut generator = SchemaGenerator::default();
+
+generator.add::<RootConfig>();
+generator.generate(output_dir.join("RootConfig.md"), ApiDocsRenderer::default())?;
+
+// Nested by `RootConfig`, so already in the generator
+generator.add::<NestedConfig>();
+generator.generate(output_dir.join("NestedConfig.md"), ApiDocsRenderer::default())?;
+```
+
+Links are relative, so all pages are expected to live in the same directory, and to be named after
+the type they document.
+
+## Page structure
+
+A page starts with front matter that titles it after the type, followed by the type's description.
+A struct then lists its properties, a unit enum lists its variants, and a union lists each type it
+accepts. Types that are referenced from the page are listed at the end.
+
+```markdown
+---
+title: ServerConfig
+---
+
+Configures the HTTP server.
+
+## Properties
+
+### `port`
+
+> **Optional**
+
+The port to listen on.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `number` |
+| Default | `8080` |
+| Minimum | `1024` |
+| Environment variable | `SERVER_PORT` |
+
+### `tls`
+
+> **Nullable**
+
+TLS settings, when serving over HTTPS.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`TlsConfig`](./TlsConfig.md) |
+
+## References
+
+- [TlsConfig](./TlsConfig.md)
+```
+
+The tags after a name describe how a property may be provided: whether it is required or optional,
+nullable, deprecated (with the deprecation message when there is one), read only, write only, or
+flattened into its parent. Enum variants are tagged with whether they are the default.
+
+The table describes the type itself: its shape, default value, accepted values, constraints such as
+minimums and patterns, aliases, and the environment variable it can be set with.
+
+## Options
+
+Custom options can be passed to the renderer using
+[`ApiDocsOptions`](https://docs.rs/schematic/latest/schematic/schema/api_docs/struct.ApiDocsOptions.html).
+
+```rust
+use schematic::schema::ApiDocsOptions;
+
+ApiDocsRenderer::new(ApiDocsOptions {
+	// ...
+	..ApiDocsOptions::default()
+});
+```
+
+### Link extension
+
+Links to other pages append `.md` to the type name. Documentation tools that route on the file name
+rather than the file may want bare links instead, which the `link_extension` option controls.
+
+```rust
+ApiDocsOptions {
+	// ...
+	link_extension: "".into(),
+}
+```
+
+### Required fields
+
+When a struct is rendered, fields that are not optional, nullable, or flattened are tagged as
+required. This is enabled by default.
+
+```rust
+ApiDocsOptions {
+	// ...
+	mark_struct_fields_required: false,
+}
+```
+
+### Aliases
+
+A field's aliases are listed in its table. Disable this with the `exclude_aliases` option.
+
+```rust
+ApiDocsOptions {
+	// ...
+	exclude_aliases: true,
+}
+```

--- a/book/src/schema/generator/api-docs.md
+++ b/book/src/schema/generator/api-docs.md
@@ -45,8 +45,9 @@ the type they document.
 ## Page structure
 
 A page starts with front matter that titles it after the type, followed by the type's description.
-A struct then lists its properties, a unit enum lists its variants, and a union lists each type it
-accepts. Types that are referenced from the page are listed at the end.
+A struct then lists its properties, and an enum lists its variants, headed by the variant name. A
+union that was built by hand has no variant names, so each of its variants is headed by its type
+instead. Types that are referenced from the page are listed at the end.
 
 ```markdown
 ---

--- a/book/src/schema/generator/api-docs.md
+++ b/book/src/schema/generator/api-docs.md
@@ -180,6 +180,21 @@ ApiDocsOptions {
 
 The renderer is created for each page, so per-type values can be set when generating that type.
 
+### Custom anchors
+
+Each index entry links to its section by a fragment, rendered from the heading text by the
+`render_anchor` function. The default follows the GitHub convention that most documentation tools
+share, lowercasing the text, removing punctuation, and hyphenating spaces, so the heading
+`` `expand_array` `` is linked as `#expand_array`. A tool that ids headings differently needs the
+function to match it.
+
+```rust
+ApiDocsOptions {
+	// ...
+	render_anchor: Box::new(|heading| format!("prop-{}", heading.replace('_', "-"))),
+}
+```
+
 ### Custom links
 
 Links to other pages are rendered by the `render_link` function, which receives the name of the

--- a/book/src/schema/generator/index.md
+++ b/book/src/schema/generator/index.md
@@ -72,6 +72,7 @@ implementing the
 [`SchemaRenderer`](https://docs.rs/schematic/latest/schematic/schema/trait.SchemaRenderer.html)
 trait.
 
+- [API documentation](./api-docs.md)
 - [Config templates](./template.md)
 - [JSON schemas](./json-schema.md)
 - [TypeScript types](./typescript.md)

--- a/book/src/schema/index.md
+++ b/book/src/schema/index.md
@@ -91,6 +91,7 @@ The following Cargo features are available:
 
 Learn more about [renderers](./generator/index.md).
 
+- `renderer_api_docs` - Enables markdown API documentation generation.
 - `renderer_json_schema` - Enables JSON schema generation.
 - `renderer_template` - Enables config template generation.
 - `renderer_typescript` - Enables TypeScript types generation.

--- a/book/src/schema/union.md
+++ b/book/src/schema/union.md
@@ -43,6 +43,15 @@ schema.union(UnionType::new_one([
 ]));
 ```
 
+## Variant names
+
+A union derived from an enum with `#[derive(Config)]` or `#[derive(Schematic)]` records the name of
+each variant in `variants_names`, by position in `variants_types`, so that renderers such as
+[API documentation](./generator/api-docs.md) can label a variant. A union built by hand carries no
+names, and
+[`UnionType::get_variant_name()`](https://docs.rs/schematic/latest/schematic/schema/struct.UnionType.html#method.get_variant_name)
+returns `None` for it.
+
 ## Operators
 
 Unions support 2 kinds of operators, any of and one of, both of which can be defined with the

--- a/crates/core/src/container.rs
+++ b/crates/core/src/container.rs
@@ -919,6 +919,7 @@ impl Container {
                 let tag_format = self.get_tag_format();
                 let mut default_index = quote! { None };
                 let mut types = vec![];
+                let mut named_types = vec![];
 
                 for variant in variants {
                     if variant.is_excluded() {
@@ -931,15 +932,20 @@ impl Container {
                         default_index = quote! { Some(#index) };
                     }
 
-                    types.push(variant.impl_schema_type(&tag_format));
+                    let name = variant.get_name();
+                    let ty = variant.impl_schema_type(&tag_format);
+
+                    named_types.push(quote! { (#name.into(), #ty) });
+                    types.push(ty);
                 }
 
                 // Enums of only units are enumerable values,
-                // otherwise they're a union of schemas
+                // otherwise they're a union of schemas. A union variant's
+                // schema is its value alone, so the name travels beside it.
                 let builder = if unit {
                     quote! { schema.enumerable(EnumType::from_schemas([#(#types),*], #default_index)) }
                 } else {
-                    quote! { schema.union(UnionType::from_schemas([#(#types),*], #default_index)) }
+                    quote! { schema.union(UnionType::from_named_schemas([#(#named_types),*], #default_index)) }
                 };
 
                 quote! {

--- a/crates/core/tests/snapshots/container_schema_test__schema_type__unnamed_enum__supports_adjacent_tag.snap
+++ b/crates/core/tests/snapshots/container_schema_test__schema_type__unnamed_enum__supports_adjacent_tag.snap
@@ -5,127 +5,151 @@ expression: pretty_body(container.impl_schematic_type())
 fn build_schema(mut schema: SchemaBuilder) -> Schema {
     schema
         .union(
-            UnionType::from_schemas(
+            UnionType::from_named_schemas(
                 [
-                    {
-                        let mut item = Schema::structure(
+                    (
+                        "Text".into(),
+                        {
+                            let mut item = Schema::structure(
+                                StructType::new([
+                                    (
+                                        "type".into(),
+                                        Schema::literal_value(LiteralValue::String("Text".into())),
+                                    ),
+                                    ("value".into(), schema.infer::<String>()),
+                                ]),
+                            );
+                            item.description = Some("Docs.".into());
+                            item
+                        },
+                    ),
+                    (
+                        "List".into(),
+                        Schema::structure(
                             StructType::new([
                                 (
                                     "type".into(),
-                                    Schema::literal_value(LiteralValue::String("Text".into())),
+                                    Schema::literal_value(LiteralValue::String("List".into())),
                                 ),
-                                ("value".into(), schema.infer::<String>()),
+                                ("value".into(), schema.infer::<Vec<String>>()),
                             ]),
-                        );
-                        item.description = Some("Docs.".into());
-                        item
-                    },
-                    Schema::structure(
-                        StructType::new([
-                            (
-                                "type".into(),
-                                Schema::literal_value(LiteralValue::String("List".into())),
-                            ),
-                            ("value".into(), schema.infer::<Vec<String>>()),
-                        ]),
+                        ),
                     ),
-                    Schema::structure(
-                        StructType::new([
-                            (
-                                "type".into(),
-                                Schema::literal_value(LiteralValue::String("Pair".into())),
-                            ),
-                            (
-                                "value".into(),
-                                Schema::tuple(
-                                    TupleType::new([
-                                        schema.infer::<usize>(),
-                                        schema.infer::<bool>(),
-                                    ]),
+                    (
+                        "Pair".into(),
+                        Schema::structure(
+                            StructType::new([
+                                (
+                                    "type".into(),
+                                    Schema::literal_value(LiteralValue::String("Pair".into())),
                                 ),
-                            ),
-                        ]),
-                    ),
-                    Schema::structure(
-                        StructType::new([
-                            (
-                                "type".into(),
-                                Schema::literal_value(LiteralValue::String("Inner".into())),
-                            ),
-                            (
-                                "value".into(),
-                                {
-                                    let mut item = schema.infer_as_nested::<NestedConfig>();
-                                    item.partialize();
-                                    item
-                                },
-                            ),
-                        ]),
-                    ),
-                    Schema::structure(
-                        StructType::new([
-                            (
-                                "type".into(),
-                                Schema::literal_value(
-                                    LiteralValue::String("InnerOpt".into()),
+                                (
+                                    "value".into(),
+                                    Schema::tuple(
+                                        TupleType::new([
+                                            schema.infer::<usize>(),
+                                            schema.infer::<bool>(),
+                                        ]),
+                                    ),
                                 ),
-                            ),
-                            (
-                                "value".into(),
-                                {
-                                    let mut item = schema
-                                        .infer_as_nested::<Option<NestedConfig>>();
-                                    item.partialize();
-                                    item
-                                },
-                            ),
-                        ]),
+                            ]),
+                        ),
                     ),
-                    Schema::structure(
-                        StructType::new([
-                            (
-                                "type".into(),
-                                Schema::literal_value(
-                                    LiteralValue::String("InnerList".into()),
+                    (
+                        "Inner".into(),
+                        Schema::structure(
+                            StructType::new([
+                                (
+                                    "type".into(),
+                                    Schema::literal_value(LiteralValue::String("Inner".into())),
                                 ),
-                            ),
-                            (
-                                "value".into(),
-                                {
-                                    let mut item = schema
-                                        .infer_as_nested::<Vec<NestedConfig>>();
-                                    item.partialize();
-                                    item
-                                },
-                            ),
-                        ]),
-                    ),
-                    Schema::structure(
-                        StructType::new([
-                            (
-                                "type".into(),
-                                Schema::literal_value(
-                                    LiteralValue::String("InnerMap".into()),
+                                (
+                                    "value".into(),
+                                    {
+                                        let mut item = schema.infer_as_nested::<NestedConfig>();
+                                        item.partialize();
+                                        item
+                                    },
                                 ),
-                            ),
-                            (
-                                "value".into(),
-                                {
-                                    let mut item = schema
-                                        .infer_as_nested::<HashMap<String, CustomConfig>>();
-                                    item.partialize();
-                                    item
-                                },
-                            ),
-                        ]),
+                            ]),
+                        ),
                     ),
-                    Schema::structure(
-                        StructType::new([
-                            (
-                                "type".into(),
-                                Schema::literal_value(LiteralValue::String("Unit".into())),
-                            ),
-                        ]),
+                    (
+                        "InnerOpt".into(),
+                        Schema::structure(
+                            StructType::new([
+                                (
+                                    "type".into(),
+                                    Schema::literal_value(
+                                        LiteralValue::String("InnerOpt".into()),
+                                    ),
+                                ),
+                                (
+                                    "value".into(),
+                                    {
+                                        let mut item = schema
+                                            .infer_as_nested::<Option<NestedConfig>>();
+                                        item.partialize();
+                                        item
+                                    },
+                                ),
+                            ]),
+                        ),
+                    ),
+                    (
+                        "InnerList".into(),
+                        Schema::structure(
+                            StructType::new([
+                                (
+                                    "type".into(),
+                                    Schema::literal_value(
+                                        LiteralValue::String("InnerList".into()),
+                                    ),
+                                ),
+                                (
+                                    "value".into(),
+                                    {
+                                        let mut item = schema
+                                            .infer_as_nested::<Vec<NestedConfig>>();
+                                        item.partialize();
+                                        item
+                                    },
+                                ),
+                            ]),
+                        ),
+                    ),
+                    (
+                        "InnerMap".into(),
+                        Schema::structure(
+                            StructType::new([
+                                (
+                                    "type".into(),
+                                    Schema::literal_value(
+                                        LiteralValue::String("InnerMap".into()),
+                                    ),
+                                ),
+                                (
+                                    "value".into(),
+                                    {
+                                        let mut item = schema
+                                            .infer_as_nested::<HashMap<String, CustomConfig>>();
+                                        item.partialize();
+                                        item
+                                    },
+                                ),
+                            ]),
+                        ),
+                    ),
+                    (
+                        "Unit".into(),
+                        Schema::structure(
+                            StructType::new([
+                                (
+                                    "type".into(),
+                                    Schema::literal_value(LiteralValue::String("Unit".into())),
+                                ),
+                            ]),
+                        ),
                     ),
                 ],
                 Some(2usize),

--- a/crates/core/tests/snapshots/container_schema_test__schema_type__unnamed_enum__supports_external.snap
+++ b/crates/core/tests/snapshots/container_schema_test__schema_type__unnamed_enum__supports_external.snap
@@ -5,83 +5,109 @@ expression: pretty_body(container.impl_schematic_type())
 fn build_schema(mut schema: SchemaBuilder) -> Schema {
     schema
         .union(
-            UnionType::from_schemas(
+            UnionType::from_named_schemas(
                 [
-                    {
-                        let mut item = Schema::structure(
-                            StructType::new([("Text".into(), schema.infer::<String>())]),
-                        );
-                        item.description = Some("Docs.".into());
-                        item
-                    },
-                    Schema::structure(
-                        StructType::new([("List".into(), schema.infer::<Vec<String>>())]),
+                    (
+                        "Text".into(),
+                        {
+                            let mut item = Schema::structure(
+                                StructType::new([("Text".into(), schema.infer::<String>())]),
+                            );
+                            item.description = Some("Docs.".into());
+                            item
+                        },
                     ),
-                    Schema::structure(
-                        StructType::new([
-                            (
-                                "Pair".into(),
-                                Schema::tuple(
-                                    TupleType::new([
-                                        schema.infer::<usize>(),
-                                        schema.infer::<bool>(),
-                                    ]),
+                    (
+                        "List".into(),
+                        Schema::structure(
+                            StructType::new([
+                                ("List".into(), schema.infer::<Vec<String>>()),
+                            ]),
+                        ),
+                    ),
+                    (
+                        "Pair".into(),
+                        Schema::structure(
+                            StructType::new([
+                                (
+                                    "Pair".into(),
+                                    Schema::tuple(
+                                        TupleType::new([
+                                            schema.infer::<usize>(),
+                                            schema.infer::<bool>(),
+                                        ]),
+                                    ),
                                 ),
-                            ),
-                        ]),
+                            ]),
+                        ),
                     ),
-                    Schema::structure(
-                        StructType::new([
-                            (
-                                "Inner".into(),
-                                {
-                                    let mut item = schema.infer_as_nested::<NestedConfig>();
-                                    item.partialize();
-                                    item
-                                },
-                            ),
-                        ]),
+                    (
+                        "Inner".into(),
+                        Schema::structure(
+                            StructType::new([
+                                (
+                                    "Inner".into(),
+                                    {
+                                        let mut item = schema.infer_as_nested::<NestedConfig>();
+                                        item.partialize();
+                                        item
+                                    },
+                                ),
+                            ]),
+                        ),
                     ),
-                    Schema::structure(
-                        StructType::new([
-                            (
-                                "InnerOpt".into(),
-                                {
-                                    let mut item = schema
-                                        .infer_as_nested::<Option<NestedConfig>>();
-                                    item.partialize();
-                                    item
-                                },
-                            ),
-                        ]),
+                    (
+                        "InnerOpt".into(),
+                        Schema::structure(
+                            StructType::new([
+                                (
+                                    "InnerOpt".into(),
+                                    {
+                                        let mut item = schema
+                                            .infer_as_nested::<Option<NestedConfig>>();
+                                        item.partialize();
+                                        item
+                                    },
+                                ),
+                            ]),
+                        ),
                     ),
-                    Schema::structure(
-                        StructType::new([
-                            (
-                                "InnerList".into(),
-                                {
-                                    let mut item = schema
-                                        .infer_as_nested::<Vec<NestedConfig>>();
-                                    item.partialize();
-                                    item
-                                },
-                            ),
-                        ]),
+                    (
+                        "InnerList".into(),
+                        Schema::structure(
+                            StructType::new([
+                                (
+                                    "InnerList".into(),
+                                    {
+                                        let mut item = schema
+                                            .infer_as_nested::<Vec<NestedConfig>>();
+                                        item.partialize();
+                                        item
+                                    },
+                                ),
+                            ]),
+                        ),
                     ),
-                    Schema::structure(
-                        StructType::new([
-                            (
-                                "InnerMap".into(),
-                                {
-                                    let mut item = schema
-                                        .infer_as_nested::<HashMap<String, CustomConfig>>();
-                                    item.partialize();
-                                    item
-                                },
-                            ),
-                        ]),
+                    (
+                        "InnerMap".into(),
+                        Schema::structure(
+                            StructType::new([
+                                (
+                                    "InnerMap".into(),
+                                    {
+                                        let mut item = schema
+                                            .infer_as_nested::<HashMap<String, CustomConfig>>();
+                                        item.partialize();
+                                        item
+                                    },
+                                ),
+                            ]),
+                        ),
                     ),
-                    Schema::literal_value(LiteralValue::String("Unit".into())),
+                    (
+                        "Unit".into(),
+                        Schema::literal_value(LiteralValue::String("Unit".into())),
+                    ),
                 ],
                 Some(2usize),
             ),

--- a/crates/core/tests/snapshots/container_schema_test__schema_type__unnamed_enum__supports_internal_tag.snap
+++ b/crates/core/tests/snapshots/container_schema_test__schema_type__unnamed_enum__supports_internal_tag.snap
@@ -5,125 +5,150 @@ expression: pretty_body(container.impl_schematic_type())
 fn build_schema(mut schema: SchemaBuilder) -> Schema {
     schema
         .union(
-            UnionType::from_schemas(
+            UnionType::from_named_schemas(
                 [
-                    {
-                        let mut item = {
-                            let mut item = schema.infer::<String>();
+                    (
+                        "Text".into(),
+                        {
+                            let mut item = {
+                                let mut item = schema.infer::<String>();
+                                item.ty
+                                    .add_field(
+                                        "type",
+                                        SchemaField::new(
+                                            Schema::literal_value(LiteralValue::String("Text".into())),
+                                        ),
+                                    );
+                                item
+                            };
+                            item.description = Some("Docs.".into());
+                            item
+                        },
+                    ),
+                    (
+                        "List".into(),
+                        {
+                            let mut item = schema.infer::<Vec<String>>();
                             item.ty
                                 .add_field(
                                     "type",
                                     SchemaField::new(
-                                        Schema::literal_value(LiteralValue::String("Text".into())),
+                                        Schema::literal_value(LiteralValue::String("List".into())),
                                     ),
                                 );
                             item
-                        };
-                        item.description = Some("Docs.".into());
-                        item
-                    },
-                    {
-                        let mut item = schema.infer::<Vec<String>>();
-                        item.ty
-                            .add_field(
-                                "type",
-                                SchemaField::new(
-                                    Schema::literal_value(LiteralValue::String("List".into())),
-                                ),
+                        },
+                    ),
+                    (
+                        "Pair".into(),
+                        {
+                            let mut item = Schema::tuple(
+                                TupleType::new([
+                                    schema.infer::<usize>(),
+                                    schema.infer::<bool>(),
+                                ]),
                             );
-                        item
-                    },
-                    {
-                        let mut item = Schema::tuple(
-                            TupleType::new([
-                                schema.infer::<usize>(),
-                                schema.infer::<bool>(),
+                            item.ty
+                                .add_field(
+                                    "type",
+                                    SchemaField::new(
+                                        Schema::literal_value(LiteralValue::String("Pair".into())),
+                                    ),
+                                );
+                            item
+                        },
+                    ),
+                    (
+                        "Inner".into(),
+                        {
+                            let mut item = {
+                                let mut item = schema.infer_as_nested::<NestedConfig>();
+                                item.ty
+                                    .add_field(
+                                        "type",
+                                        SchemaField::new(
+                                            Schema::literal_value(LiteralValue::String("Inner".into())),
+                                        ),
+                                    );
+                                item
+                            };
+                            item.partialize();
+                            item
+                        },
+                    ),
+                    (
+                        "InnerOpt".into(),
+                        {
+                            let mut item = {
+                                let mut item = schema
+                                    .infer_as_nested::<Option<NestedConfig>>();
+                                item.ty
+                                    .add_field(
+                                        "type",
+                                        SchemaField::new(
+                                            Schema::literal_value(
+                                                LiteralValue::String("InnerOpt".into()),
+                                            ),
+                                        ),
+                                    );
+                                item
+                            };
+                            item.partialize();
+                            item
+                        },
+                    ),
+                    (
+                        "InnerList".into(),
+                        {
+                            let mut item = {
+                                let mut item = schema
+                                    .infer_as_nested::<Vec<NestedConfig>>();
+                                item.ty
+                                    .add_field(
+                                        "type",
+                                        SchemaField::new(
+                                            Schema::literal_value(
+                                                LiteralValue::String("InnerList".into()),
+                                            ),
+                                        ),
+                                    );
+                                item
+                            };
+                            item.partialize();
+                            item
+                        },
+                    ),
+                    (
+                        "InnerMap".into(),
+                        {
+                            let mut item = {
+                                let mut item = schema
+                                    .infer_as_nested::<HashMap<String, CustomConfig>>();
+                                item.ty
+                                    .add_field(
+                                        "type",
+                                        SchemaField::new(
+                                            Schema::literal_value(
+                                                LiteralValue::String("InnerMap".into()),
+                                            ),
+                                        ),
+                                    );
+                                item
+                            };
+                            item.partialize();
+                            item
+                        },
+                    ),
+                    (
+                        "Unit".into(),
+                        Schema::structure(
+                            StructType::new([
+                                (
+                                    "type".into(),
+                                    Schema::literal_value(LiteralValue::String("Unit".into())),
+                                ),
                             ]),
-                        );
-                        item.ty
-                            .add_field(
-                                "type",
-                                SchemaField::new(
-                                    Schema::literal_value(LiteralValue::String("Pair".into())),
-                                ),
-                            );
-                        item
-                    },
-                    {
-                        let mut item = {
-                            let mut item = schema.infer_as_nested::<NestedConfig>();
-                            item.ty
-                                .add_field(
-                                    "type",
-                                    SchemaField::new(
-                                        Schema::literal_value(LiteralValue::String("Inner".into())),
-                                    ),
-                                );
-                            item
-                        };
-                        item.partialize();
-                        item
-                    },
-                    {
-                        let mut item = {
-                            let mut item = schema
-                                .infer_as_nested::<Option<NestedConfig>>();
-                            item.ty
-                                .add_field(
-                                    "type",
-                                    SchemaField::new(
-                                        Schema::literal_value(
-                                            LiteralValue::String("InnerOpt".into()),
-                                        ),
-                                    ),
-                                );
-                            item
-                        };
-                        item.partialize();
-                        item
-                    },
-                    {
-                        let mut item = {
-                            let mut item = schema.infer_as_nested::<Vec<NestedConfig>>();
-                            item.ty
-                                .add_field(
-                                    "type",
-                                    SchemaField::new(
-                                        Schema::literal_value(
-                                            LiteralValue::String("InnerList".into()),
-                                        ),
-                                    ),
-                                );
-                            item
-                        };
-                        item.partialize();
-                        item
-                    },
-                    {
-                        let mut item = {
-                            let mut item = schema
-                                .infer_as_nested::<HashMap<String, CustomConfig>>();
-                            item.ty
-                                .add_field(
-                                    "type",
-                                    SchemaField::new(
-                                        Schema::literal_value(
-                                            LiteralValue::String("InnerMap".into()),
-                                        ),
-                                    ),
-                                );
-                            item
-                        };
-                        item.partialize();
-                        item
-                    },
-                    Schema::structure(
-                        StructType::new([
-                            (
-                                "type".into(),
-                                Schema::literal_value(LiteralValue::String("Unit".into())),
-                            ),
-                        ]),
+                        ),
                     ),
                 ],
                 Some(2usize),

--- a/crates/core/tests/snapshots/container_schema_test__schema_type__unnamed_enum__supports_renames_and_exclusions.snap
+++ b/crates/core/tests/snapshots/container_schema_test__schema_type__unnamed_enum__supports_renames_and_exclusions.snap
@@ -5,16 +5,25 @@ expression: pretty_body(container.impl_schematic_type())
 fn build_schema(mut schema: SchemaBuilder) -> Schema {
     schema
         .union(
-            UnionType::from_schemas(
+            UnionType::from_named_schemas(
                 [
-                    Schema::structure(
-                        StructType::new([("text".into(), schema.infer::<String>())]),
+                    (
+                        "text".into(),
+                        Schema::structure(
+                            StructType::new([("text".into(), schema.infer::<String>())]),
+                        ),
                     ),
-                    Schema::structure(
-                        StructType::new([("number".into(), schema.infer::<usize>())]),
+                    (
+                        "number".into(),
+                        Schema::structure(
+                            StructType::new([("number".into(), schema.infer::<usize>())]),
+                        ),
                     ),
-                    Schema::structure(
-                        StructType::new([("Last".into(), schema.infer::<bool>())]),
+                    (
+                        "Last".into(),
+                        Schema::structure(
+                            StructType::new([("Last".into(), schema.infer::<bool>())]),
+                        ),
                     ),
                 ],
                 Some(2usize),

--- a/crates/core/tests/snapshots/container_schema_test__schema_type__unnamed_enum__supports_untagged.snap
+++ b/crates/core/tests/snapshots/container_schema_test__schema_type__unnamed_enum__supports_untagged.snap
@@ -5,22 +5,37 @@ expression: pretty_body(container.impl_schematic_type())
 fn build_schema(mut schema: SchemaBuilder) -> Schema {
     schema
         .union(
-            UnionType::from_schemas(
+            UnionType::from_named_schemas(
                 [
-                    {
-                        let mut item = schema.infer::<String>();
-                        item.description = Some("Docs.".into());
-                        item
-                    },
-                    schema.infer::<Vec<String>>(),
-                    Schema::tuple(
-                        TupleType::new([schema.infer::<usize>(), schema.infer::<bool>()]),
+                    (
+                        "Text".into(),
+                        {
+                            let mut item = schema.infer::<String>();
+                            item.description = Some("Docs.".into());
+                            item
+                        },
                     ),
-                    schema.infer_as_nested::<NestedConfig>(),
-                    schema.infer_as_nested::<Option<NestedConfig>>(),
-                    schema.infer_as_nested::<Vec<NestedConfig>>(),
-                    schema.infer_as_nested::<HashMap<String, CustomConfig>>(),
-                    Schema::null(),
+                    ("List".into(), schema.infer::<Vec<String>>()),
+                    (
+                        "Pair".into(),
+                        Schema::tuple(
+                            TupleType::new([
+                                schema.infer::<usize>(),
+                                schema.infer::<bool>(),
+                            ]),
+                        ),
+                    ),
+                    ("Inner".into(), schema.infer_as_nested::<NestedConfig>()),
+                    (
+                        "InnerOpt".into(),
+                        schema.infer_as_nested::<Option<NestedConfig>>(),
+                    ),
+                    ("InnerList".into(), schema.infer_as_nested::<Vec<NestedConfig>>()),
+                    (
+                        "InnerMap".into(),
+                        schema.infer_as_nested::<HashMap<String, CustomConfig>>(),
+                    ),
+                    ("Unit".into(), Schema::null()),
                 ],
                 Some(2usize),
             ),

--- a/crates/core/tests/snapshots/container_schema_test__schema_type__unnamed_enum__supports_variant_untagged.snap
+++ b/crates/core/tests/snapshots/container_schema_test__schema_type__unnamed_enum__supports_variant_untagged.snap
@@ -5,21 +5,24 @@ expression: pretty_body(container.impl_schematic_type())
 fn build_schema(mut schema: SchemaBuilder) -> Schema {
     schema
         .union(
-            UnionType::from_schemas(
+            UnionType::from_named_schemas(
                 [
-                    {
-                        let mut item = schema.infer::<String>();
-                        item.ty
-                            .add_field(
-                                "type",
-                                SchemaField::new(
-                                    Schema::literal_value(LiteralValue::String("Text".into())),
-                                ),
-                            );
-                        item
-                    },
-                    schema.infer::<String>(),
-                    schema.infer::<String>(),
+                    (
+                        "Text".into(),
+                        {
+                            let mut item = schema.infer::<String>();
+                            item.ty
+                                .add_field(
+                                    "type",
+                                    SchemaField::new(
+                                        Schema::literal_value(LiteralValue::String("Text".into())),
+                                    ),
+                                );
+                            item
+                        },
+                    ),
+                    ("Inner".into(), schema.infer::<String>()),
+                    ("Other".into(), schema.infer::<String>()),
                 ],
                 None,
             ),

--- a/crates/core/tests/snapshots/container_schema_test__schematic__unnamed_enum.snap
+++ b/crates/core/tests/snapshots/container_schema_test__schematic__unnamed_enum.snap
@@ -11,10 +11,13 @@ impl schematic::Schematic for Example {
         use schematic::schema::*;
         schema
             .union(
-                UnionType::from_schemas(
+                UnionType::from_named_schemas(
                     [
-                        Schema::structure(
-                            StructType::new([("A".into(), schema.infer::<bool>())]),
+                        (
+                            "A".into(),
+                            Schema::structure(
+                                StructType::new([("A".into(), schema.infer::<bool>())]),
+                            ),
                         ),
                     ],
                     None,

--- a/crates/core/tests/snapshots/container_type_test__generics__unnamed_enum.snap
+++ b/crates/core/tests/snapshots/container_type_test__generics__unnamed_enum.snap
@@ -90,12 +90,18 @@ impl<T> schematic::Schematic for Example<T> {
         use schematic::schema::*;
         schema
             .union(
-                UnionType::from_schemas(
+                UnionType::from_named_schemas(
                     [
-                        Schema::structure(
-                            StructType::new([("Value".into(), schema.infer::<T>())]),
+                        (
+                            "Value".into(),
+                            Schema::structure(
+                                StructType::new([("Value".into(), schema.infer::<T>())]),
+                            ),
                         ),
-                        Schema::literal_value(LiteralValue::String("Nothing".into())),
+                        (
+                            "Nothing".into(),
+                            Schema::literal_value(LiteralValue::String("Nothing".into())),
+                        ),
                     ],
                     Some(1usize),
                 ),

--- a/crates/core/tests/snapshots/container_type_test__to_tokens__unnamed_enum.snap
+++ b/crates/core/tests/snapshots/container_type_test__to_tokens__unnamed_enum.snap
@@ -202,12 +202,12 @@ impl schematic::Schematic for Example {
         use schematic::schema::*;
         schema
             .union(
-                UnionType::from_schemas(
+                UnionType::from_named_schemas(
                     [
-                        schema.infer::<bool>(),
-                        schema.infer::<usize>(),
-                        schema.infer_as_nested::<NestedConfig>(),
-                        schema.infer_as_nested::<Vec<NestedConfig>>(),
+                        ("Bool".into(), schema.infer::<bool>()),
+                        ("Number".into(), schema.infer::<usize>()),
+                        ("Nested".into(), schema.infer_as_nested::<NestedConfig>()),
+                        ("List".into(), schema.infer_as_nested::<Vec<NestedConfig>>()),
                     ],
                     Some(0usize),
                 ),

--- a/crates/core/tests/snapshots/derive_schematic_test__standalone__unnamed_enum.snap
+++ b/crates/core/tests/snapshots/derive_schematic_test__standalone__unnamed_enum.snap
@@ -11,13 +11,19 @@ impl schematic::Schematic for Example {
         use schematic::schema::*;
         schema
             .union(
-                UnionType::from_schemas(
+                UnionType::from_named_schemas(
                     [
-                        Schema::structure(
-                            StructType::new([("A".into(), schema.infer::<bool>())]),
+                        (
+                            "A".into(),
+                            Schema::structure(
+                                StructType::new([("A".into(), schema.infer::<bool>())]),
+                            ),
                         ),
-                        Schema::structure(
-                            StructType::new([("B".into(), schema.infer::<String>())]),
+                        (
+                            "B".into(),
+                            Schema::structure(
+                                StructType::new([("B".into(), schema.infer::<String>())]),
+                            ),
                         ),
                     ],
                     None,

--- a/crates/schematic/Cargo.toml
+++ b/crates/schematic/Cargo.toml
@@ -95,6 +95,7 @@ toml = ["dep:toml", "schematic_types/serde_toml"]
 yaml = ["dep:serde_norway", "schematic_types/serde_yaml_norway"]
 
 # Renderers
+renderer_api_docs = ["schema"]
 renderer_json_schema = ["json", "schema", "dep:markdown", "dep:schemars"]
 renderer_template = ["schema"]
 renderer_typescript = ["schema"]
@@ -120,6 +121,7 @@ schematic = { path = ".", features = [
 	"extends",
 	"json",
 	"pkl",
+	"renderer_api_docs",
 	"renderer_json_schema",
 	"renderer_template",
 	"renderer_typescript",

--- a/crates/schematic/src/schema/generator.rs
+++ b/crates/schematic/src/schema/generator.rs
@@ -22,6 +22,11 @@ pub struct SchemaGenerator {
 impl SchemaGenerator {
     /// Add a [`Schema`] to be rendered, derived from the provided [`Schematic`].
     ///
+    /// The last type added is what renderers that produce a single document
+    /// treat as the root. Adding a type that is already present, because an
+    /// earlier type nested it, moves it to the end so that it becomes the
+    /// root.
+    ///
     /// # Panics
     ///
     /// If another type has already been added under the same schema name.
@@ -43,6 +48,12 @@ impl SchemaGenerator {
         }
 
         self.add_schema(&schema);
+
+        if let Some(name) = &schema.name
+            && let Some(index) = self.schemas.get_index_of(name)
+        {
+            self.schemas.move_index(index, self.schemas.len() - 1);
+        }
     }
 
     /// Add an explicit [`Schema`] to be rendered, and recursively add any nested schemas.

--- a/crates/schematic/src/schema/mod.rs
+++ b/crates/schematic/src/schema/mod.rs
@@ -7,6 +7,10 @@ pub use indexmap;
 pub use renderer::*;
 pub use schematic_types::*;
 
+/// Renders markdown API documentation.
+#[cfg(feature = "renderer_api_docs")]
+pub use renderers::api_docs::{self, *};
+
 /// Renders JSON schemas.
 #[cfg(feature = "renderer_json_schema")]
 pub use renderers::json_schema::{self, *};

--- a/crates/schematic/src/schema/renderers/api_docs.rs
+++ b/crates/schematic/src/schema/renderers/api_docs.rs
@@ -85,8 +85,23 @@ pub fn default_description_renderer(description: &str) -> String {
         .join("\n")
 }
 
+/// How the variants of a unit enum are rendered.
+#[derive(Debug, Default, PartialEq)]
+pub enum ApiDocsEnumFormat {
+    /// A section per variant, with its tags, description, and value.
+    #[default]
+    Sections,
+    /// A single table, one row per variant. The index is omitted, as the
+    /// table already summarizes every variant.
+    Table,
+}
+
 /// Options to control the rendered API documentation.
 pub struct ApiDocsOptions {
+    /// How the variants of a unit enum are rendered. Unions, whose variants
+    /// carry values, are always rendered as sections.
+    pub enum_format: ApiDocsEnumFormat,
+
     /// Exclude field aliases from being rendered.
     pub exclude_aliases: bool,
 
@@ -120,6 +135,7 @@ pub struct ApiDocsOptions {
 impl Default for ApiDocsOptions {
     fn default() -> Self {
         Self {
+            enum_format: ApiDocsEnumFormat::default(),
             exclude_aliases: false,
             frontmatter: BTreeMap::new(),
             include_index: true,
@@ -399,6 +415,40 @@ impl ApiDocsRenderer {
 
     fn render_description(&self, description: &str) -> Option<String> {
         Some((self.options.render_description)(description)).filter(|out| !out.is_empty())
+    }
+
+    /// The tags of an enum variant.
+    fn variant_tags(&self, variant: &SchemaField, is_default: bool) -> Vec<ApiDocsTag> {
+        let mut tags = vec![];
+
+        if is_default {
+            tags.push(ApiDocsTag::Default);
+        }
+
+        if let Some(deprecated) = variant
+            .deprecated
+            .as_deref()
+            .or(variant.schema.deprecated.as_deref())
+        {
+            tags.push(self.deprecated_tag(deprecated));
+        }
+
+        tags
+    }
+
+    /// Tags as a comma separated list of labels, for a table cell. A block
+    /// quote from `render_tags` cannot sit inside a cell, so it isn't used.
+    fn render_inline_tags(&self, tags: &[ApiDocsTag]) -> String {
+        tags.iter()
+            .map(|tag| match tag {
+                ApiDocsTag::Deprecated(Some(message)) => {
+                    format!("**{}** ({})", tag.label(), message.trim())
+                }
+                _ => format!("**{}**", tag.label()),
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+            .replace('|', "\\|")
     }
 
     fn deprecated_tag(&self, message: &str) -> ApiDocsTag {
@@ -694,21 +744,8 @@ impl ApiDocsRenderer {
         is_default: bool,
     ) -> RenderResult {
         let mut out = vec![format!("### {}", code(name))];
-        let mut tags = vec![];
 
-        if is_default {
-            tags.push(ApiDocsTag::Default);
-        }
-
-        if let Some(deprecated) = variant
-            .deprecated
-            .as_ref()
-            .or(variant.schema.deprecated.as_ref())
-        {
-            tags.push(self.deprecated_tag(deprecated));
-        }
-
-        if let Some(tags) = self.render_tags(tags) {
+        if let Some(tags) = self.render_tags(self.variant_tags(variant, is_default)) {
             out.push(tags);
         }
 
@@ -759,6 +796,10 @@ impl ApiDocsRenderer {
                 .collect(),
         };
 
+        if self.options.enum_format == ApiDocsEnumFormat::Table {
+            return self.render_enum_table(enu, &variants);
+        }
+
         let mut index = vec![];
         let mut sections = vec![];
 
@@ -786,6 +827,49 @@ impl ApiDocsRenderer {
         }
 
         Ok(self.assemble_sections("Variant", "## Variants", index, sections))
+    }
+
+    /// The variants of a unit enum as one table, a row per variant. A
+    /// fallback variant, which accepts a type rather than a value, shows
+    /// that type in the value column.
+    fn render_enum_table(
+        &mut self,
+        enu: &EnumType,
+        variants: &[(String, SchemaField)],
+    ) -> RenderResult {
+        let mut rows = vec![];
+
+        for (position, (name, variant)) in variants.iter().enumerate() {
+            if variant.hidden {
+                continue;
+            }
+
+            let expr = self.render_schema(&variant.schema)?;
+            let tags = self.variant_tags(variant, enu.default_index == Some(position));
+            let description = variant
+                .comment
+                .as_deref()
+                .or(variant.schema.description.as_deref())
+                .map(summarize)
+                .unwrap_or_default();
+
+            rows.push(format!(
+                "| {} | {} | {} | {} |",
+                code(name),
+                self.render_type_expression(&expr),
+                self.render_inline_tags(&tags),
+                description,
+            ));
+        }
+
+        if rows.is_empty() {
+            return Ok(String::new());
+        }
+
+        Ok(format!(
+            "## Variants\n\n| Variant | Value | Tags | Description |\n| --- | --- | --- | --- |\n{}",
+            rows.join("\n")
+        ))
     }
 
     /// A page for a union, such as an untagged enum, which lists each variant.

--- a/crates/schematic/src/schema/renderers/api_docs.rs
+++ b/crates/schematic/src/schema/renderers/api_docs.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 use miette::miette;
 use schematic_types::*;
 use std::borrow::Cow;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt;
 
 /// A tag describing how a type, property, or variant may be provided.
@@ -90,6 +90,11 @@ pub struct ApiDocsOptions {
     /// Exclude field aliases from being rendered.
     pub exclude_aliases: bool,
 
+    /// Additional frontmatter entries, written as `key: value` lines after
+    /// the title, in key order. Values are written verbatim, so quote them
+    /// as the consuming tool expects. A `title` entry replaces the type name.
+    pub frontmatter: BTreeMap<String, String>,
+
     /// Render an index of all properties or variants, linking to each
     /// section, ahead of the sections themselves.
     pub include_index: bool,
@@ -116,6 +121,7 @@ impl Default for ApiDocsOptions {
     fn default() -> Self {
         Self {
             exclude_aliases: false,
+            frontmatter: BTreeMap::new(),
             include_index: true,
             link_extension: ".md".into(),
             mark_struct_fields_required: true,
@@ -871,8 +877,28 @@ impl ApiDocsRenderer {
         Ok(format!("## Type\n\n{}", self.render_table(rows)))
     }
 
+    fn render_frontmatter(&self, name: &str) -> String {
+        let title = self
+            .options
+            .frontmatter
+            .get("title")
+            .map(String::as_str)
+            .unwrap_or(name);
+        let mut lines = vec!["---".to_owned(), format!("title: {title}")];
+
+        // Sorted so that the output is stable no matter how the map iterates
+        for (key, value) in &self.options.frontmatter {
+            if key != "title" {
+                lines.push(format!("{key}: {value}"));
+            }
+        }
+
+        lines.push("---".to_owned());
+        lines.join("\n")
+    }
+
     fn render_page(&mut self, name: &str, schema: &Schema) -> RenderResult {
-        let mut out = vec![format!("---\ntitle: {name}\n---")];
+        let mut out = vec![self.render_frontmatter(name)];
         let mut tags = vec![];
 
         if let Some(deprecated) = &schema.deprecated {

--- a/crates/schematic/src/schema/renderers/api_docs.rs
+++ b/crates/schematic/src/schema/renderers/api_docs.rs
@@ -254,6 +254,26 @@ impl TypeExpression {
     pub fn is_union(&self) -> bool {
         self.is_union
     }
+
+    /// Return true if the expression is nothing but a reference to a type.
+    pub fn is_reference(&self) -> bool {
+        matches!(self.parts.as_slice(), [TypePart::Reference(_)])
+    }
+
+    /// The types the expression refers to, in order of first appearance.
+    pub fn references(&self) -> Vec<&str> {
+        let mut names: Vec<&str> = vec![];
+
+        for part in &self.parts {
+            if let TypePart::Reference(name) = part
+                && !names.contains(&name.as_str())
+            {
+                names.push(name);
+            }
+        }
+
+        names
+    }
 }
 
 /// The expression as plain text, with references reduced to their names.
@@ -491,17 +511,47 @@ impl ApiDocsRenderer {
         (self.options.render_link)(name)
     }
 
+    /// Render a type expression as a single code span, or as a link when it
+    /// is nothing but a reference. A link cannot sit inside a code span, so
+    /// the types a composite expression refers to are linked separately by
+    /// [`Self::render_type_references`].
     fn render_type_expression(&self, expr: &TypeExpression) -> String {
-        let mut out = String::new();
+        match expr.references().as_slice() {
+            [name] if expr.is_reference() => self.create_link(name),
+            _ => code(expr.to_string()),
+        }
+    }
 
-        for part in &expr.parts {
-            match part {
-                TypePart::Code(value) => out.push_str(&code(value)),
-                TypePart::Reference(name) => out.push_str(&self.create_link(name)),
-            }
+    /// Links to the types a composite expression refers to, or `None` when
+    /// it refers to nothing, or is itself rendered as a link.
+    fn render_type_references(&self, expr: &TypeExpression) -> Option<String> {
+        if expr.is_reference() {
+            return None;
         }
 
-        out
+        let links = expr
+            .references()
+            .into_iter()
+            .map(|name| self.create_link(name))
+            .collect::<Vec<_>>();
+
+        if links.is_empty() {
+            None
+        } else {
+            Some(links.join(", "))
+        }
+    }
+
+    /// The rows describing a type in a table: the type itself, and the
+    /// types it refers to when they cannot be linked from the type.
+    fn type_rows(&self, label: &'static str, expr: &TypeExpression) -> Vec<(&'static str, String)> {
+        let mut rows = vec![(label, self.render_type_expression(expr))];
+
+        if let Some(references) = self.render_type_references(expr) {
+            rows.push(("References", references));
+        }
+
+        rows
     }
 
     fn render_table(&self, rows: Vec<(&str, String)>) -> String {
@@ -726,7 +776,8 @@ impl ApiDocsRenderer {
     /// accepted values, and constraints.
     fn render_field_table(&mut self, field: &SchemaField) -> RenderResult {
         let schema = strip_null(&field.schema);
-        let mut rows = vec![("Type", self.render_field_type(field)?)];
+        let expr = self.render_schema(&schema)?;
+        let mut rows = self.type_rows("Type", &expr);
 
         if let Some(default) = field.schema.get_default() {
             rows.push(("Default", code(lit_to_string(default))));
@@ -878,7 +929,7 @@ impl ApiDocsRenderer {
         };
 
         let expr = self.render_schema(&variant.schema)?;
-        let mut rows = vec![(key, self.render_type_expression(&expr))];
+        let mut rows = self.type_rows(key, &expr);
 
         rows.extend(self.create_constraint_rows(&variant.schema));
 
@@ -1032,7 +1083,7 @@ impl ApiDocsRenderer {
                 section.push(description);
             }
 
-            let mut rows = vec![("Type", self.render_type_expression(&expr))];
+            let mut rows = self.type_rows("Type", &expr);
 
             if let Some(default) = variant.get_default() {
                 rows.push(("Default", code(lit_to_string(default))));
@@ -1058,7 +1109,7 @@ impl ApiDocsRenderer {
         let stripped = strip_null(schema);
         let expr = self.render_schema_without_reference(&stripped)?;
 
-        let mut rows = vec![("Type", self.render_type_expression(&expr))];
+        let mut rows = self.type_rows("Type", &expr);
 
         if let Some(default) = schema.get_default() {
             rows.push(("Default", code(lit_to_string(default))));

--- a/crates/schematic/src/schema/renderers/api_docs.rs
+++ b/crates/schematic/src/schema/renderers/api_docs.rs
@@ -182,12 +182,20 @@ fn strip_null(schema: &Schema) -> Cow<'_, Schema> {
         return Cow::Borrowed(schema);
     }
 
-    let variants_types = uni
-        .variants_types
-        .iter()
-        .filter(|variant| !variant.is_null())
-        .cloned()
-        .collect::<Vec<_>>();
+    let mut variants_types = vec![];
+    let mut variants_names = vec![];
+
+    for (index, variant) in uni.variants_types.iter().enumerate() {
+        if variant.is_null() {
+            continue;
+        }
+
+        variants_types.push(variant.clone());
+
+        if let Some(name) = uni.get_variant_name(index) {
+            variants_names.push(name.to_owned());
+        }
+    }
 
     match variants_types.len() {
         0 => Cow::Owned(Schema::null()),
@@ -195,6 +203,10 @@ fn strip_null(schema: &Schema) -> Cow<'_, Schema> {
         _ => {
             let mut stripped = schema.clone();
             stripped.ty = SchemaType::Union(Box::new(UnionType {
+                // Names travel by position, so only keep them if every kept
+                // variant still has one
+                variants_names: (variants_names.len() == variants_types.len())
+                    .then_some(variants_names),
                 variants_types,
                 ..(**uni).clone()
             }));
@@ -577,7 +589,8 @@ impl ApiDocsRenderer {
     }
 
     /// A page for a union, such as an untagged enum, which lists each variant.
-    /// Variants have no names of their own, so each is headed by its type.
+    /// A variant is headed by its name when the union was derived from an
+    /// enum, and by its type otherwise.
     fn render_union_page(&mut self, uni: &UnionType) -> RenderResult {
         let mut out = vec![];
 
@@ -588,7 +601,11 @@ impl ApiDocsRenderer {
             }
 
             let expr = self.render_schema(variant)?;
-            let mut section = vec![format!("### {}", code(expr.to_string()))];
+            let heading = match uni.get_variant_name(index) {
+                Some(name) => name.to_owned(),
+                None => expr.to_string(),
+            };
+            let mut section = vec![format!("### {}", code(heading))];
             let mut tags = vec![];
 
             if uni.default_index == Some(index) {

--- a/crates/schematic/src/schema/renderers/api_docs.rs
+++ b/crates/schematic/src/schema/renderers/api_docs.rs
@@ -1,0 +1,893 @@
+use crate::schema::{RenderResult, SchemaRenderer};
+use indexmap::IndexMap;
+use miette::miette;
+use schematic_types::*;
+use std::borrow::Cow;
+use std::collections::{BTreeSet, HashSet};
+use std::fmt;
+
+/// Options to control the rendered API documentation.
+pub struct ApiDocsOptions {
+    /// Exclude field aliases from being rendered.
+    pub exclude_aliases: bool,
+
+    /// File extension appended to the name of a referenced type when linking
+    /// to its page, such as `.md`. Set to an empty string to link to the bare
+    /// name, for documentation tools that route on the file name.
+    pub link_extension: String,
+
+    /// Tag all non-optional struct fields as required.
+    pub mark_struct_fields_required: bool,
+}
+
+impl Default for ApiDocsOptions {
+    fn default() -> Self {
+        Self {
+            exclude_aliases: false,
+            link_extension: ".md".into(),
+            mark_struct_fields_required: true,
+        }
+    }
+}
+
+/// A rendered type expression. Kept in pieces rather than as a string so that
+/// references to other pages can become links, while everything around them
+/// is rendered as inline code.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TypeExpression {
+    parts: Vec<TypePart>,
+    is_union: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum TypePart {
+    Code(String),
+    Reference(String),
+}
+
+impl TypeExpression {
+    /// Create an expression from a piece of code.
+    pub fn code(value: impl Into<String>) -> Self {
+        let mut expr = Self::default();
+        expr.push_code(value);
+        expr
+    }
+
+    /// Create an expression that refers to another type by name.
+    pub fn reference(name: impl Into<String>) -> Self {
+        Self {
+            parts: vec![TypePart::Reference(name.into())],
+            is_union: false,
+        }
+    }
+
+    /// Join expressions with a separator.
+    pub fn join<I>(exprs: I, separator: &str) -> Self
+    where
+        I: IntoIterator<Item = TypeExpression>,
+    {
+        let mut out = Self::default();
+
+        for (index, expr) in exprs.into_iter().enumerate() {
+            if index > 0 {
+                out.push_code(separator);
+            }
+
+            out.extend(expr);
+        }
+
+        out
+    }
+
+    /// Append a piece of code.
+    pub fn push_code(&mut self, value: impl Into<String>) {
+        let value = value.into();
+
+        if value.is_empty() {
+            return;
+        }
+
+        // Merge onto the previous piece of code so that the rendered output is
+        // a single code span, instead of one per piece
+        if let Some(TypePart::Code(last)) = self.parts.last_mut() {
+            last.push_str(&value);
+        } else {
+            self.parts.push(TypePart::Code(value));
+        }
+    }
+
+    /// Append another expression.
+    pub fn extend(&mut self, other: TypeExpression) {
+        for part in other.parts {
+            match part {
+                TypePart::Code(code) => self.push_code(code),
+                TypePart::Reference(name) => self.parts.push(TypePart::Reference(name)),
+            }
+        }
+    }
+
+    /// Wrap the expression in parentheses.
+    pub fn parenthesize(self) -> Self {
+        let mut out = Self::code("(");
+        out.extend(self);
+        out.push_code(")");
+        out
+    }
+
+    /// Return true if the expression is a union of types.
+    pub fn is_union(&self) -> bool {
+        self.is_union
+    }
+}
+
+/// The expression as plain text, with references reduced to their names.
+impl fmt::Display for TypeExpression {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for part in &self.parts {
+            match part {
+                TypePart::Code(value) => write!(f, "{value}")?,
+                TypePart::Reference(name) => write!(f, "{name}")?,
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn lit_to_string(lit: &LiteralValue) -> String {
+    match lit {
+        LiteralValue::Bool(inner) => inner.to_string(),
+        LiteralValue::F32(inner) => inner.to_string(),
+        LiteralValue::F64(inner) => inner.to_string(),
+        LiteralValue::Int(inner) => inner.to_string(),
+        LiteralValue::UInt(inner) => inner.to_string(),
+        LiteralValue::String(inner) => format!("\"{inner}\""),
+    }
+}
+
+/// Render a value as inline code. A pipe inside a table cell ends the cell,
+/// even within a code span, so it has to be escaped.
+fn code(value: impl AsRef<str>) -> String {
+    format!("`{}`", value.as_ref().replace('|', "\\|"))
+}
+
+/// Render a list of values as inline code, separated by commas.
+fn code_list<I, V>(values: I) -> String
+where
+    I: IntoIterator<Item = V>,
+    V: AsRef<str>,
+{
+    values.into_iter().map(code).collect::<Vec<_>>().join(", ")
+}
+
+/// Keep a description as written, so that paragraphs and lists survive.
+fn clean_comment(comment: &str) -> String {
+    comment
+        .trim()
+        .lines()
+        .map(|line| line.trim())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Remove `null` from a nullable schema, so that nullability is reported once
+/// through a tag instead of repeated in every type expression. A union that
+/// is left with a single variant collapses to that variant.
+fn strip_null(schema: &Schema) -> Cow<'_, Schema> {
+    let SchemaType::Union(uni) = &schema.ty else {
+        return Cow::Borrowed(schema);
+    };
+
+    if !uni.has_null() {
+        return Cow::Borrowed(schema);
+    }
+
+    let variants_types = uni
+        .variants_types
+        .iter()
+        .filter(|variant| !variant.is_null())
+        .cloned()
+        .collect::<Vec<_>>();
+
+    match variants_types.len() {
+        0 => Cow::Owned(Schema::null()),
+        1 => Cow::Owned(*variants_types.into_iter().next().unwrap()),
+        _ => {
+            let mut stripped = schema.clone();
+            stripped.ty = SchemaType::Union(Box::new(UnionType {
+                variants_types,
+                ..(**uni).clone()
+            }));
+            Cow::Owned(stripped)
+        }
+    }
+}
+
+/// Renders markdown API documentation from a schema, one page per type.
+#[derive(Default)]
+pub struct ApiDocsRenderer {
+    options: ApiDocsOptions,
+    references: HashSet<String>,
+
+    // Types the current page linked to, listed under "References"
+    linked: BTreeSet<String>,
+}
+
+impl ApiDocsRenderer {
+    pub fn new(options: ApiDocsOptions) -> Self {
+        Self {
+            options,
+            references: HashSet::default(),
+            linked: BTreeSet::default(),
+        }
+    }
+
+    fn create_link(&self, name: &str) -> String {
+        format!("./{name}{}", self.options.link_extension)
+    }
+
+    fn render_type_expression(&self, expr: &TypeExpression) -> String {
+        let mut out = String::new();
+
+        for part in &expr.parts {
+            match part {
+                TypePart::Code(value) => out.push_str(&code(value)),
+                TypePart::Reference(name) => {
+                    out.push_str(&format!("[{}]({})", code(name), self.create_link(name)));
+                }
+            }
+        }
+
+        out
+    }
+
+    fn render_table(&self, rows: Vec<(&str, String)>) -> String {
+        let mut out = vec![
+            "| Attribute | Value |".to_owned(),
+            "| --- | --- |".to_owned(),
+        ];
+
+        for (key, value) in rows {
+            out.push(format!("| {key} | {value} |"));
+        }
+
+        out.join("\n")
+    }
+
+    fn render_tags(&self, tags: Vec<String>) -> Option<String> {
+        if tags.is_empty() {
+            return None;
+        }
+
+        Some(format!("> {}", tags.join(" · ")))
+    }
+
+    fn deprecated_tag(&self, message: &str) -> String {
+        if message.is_empty() {
+            "**Deprecated**".to_owned()
+        } else {
+            format!("**Deprecated** ({})", message.trim())
+        }
+    }
+
+    /// Render the literal values an enumerable type accepts, for both
+    /// [`EnumType`]s and scalars constrained with `enum_values`.
+    fn render_enum_values(&self, schema: &Schema) -> Option<String> {
+        let values = match &schema.ty {
+            SchemaType::Enum(enu) => match &enu.variants {
+                Some(variants) => variants
+                    .values()
+                    .filter(|variant| !variant.hidden)
+                    .filter_map(|variant| match &variant.schema.ty {
+                        SchemaType::Literal(lit) => Some(lit_to_string(&lit.value)),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>(),
+                None => enu.values.iter().map(lit_to_string).collect(),
+            },
+            SchemaType::Float(float) => float
+                .enum_values
+                .as_ref()?
+                .iter()
+                .map(|value| value.to_string())
+                .collect(),
+            SchemaType::Integer(integer) => integer
+                .enum_values
+                .as_ref()?
+                .iter()
+                .map(|value| value.to_string())
+                .collect(),
+            SchemaType::String(string) => string
+                .enum_values
+                .as_ref()?
+                .iter()
+                .map(|value| format!("\"{value}\""))
+                .collect(),
+            _ => return None,
+        };
+
+        if values.is_empty() {
+            None
+        } else {
+            Some(code_list(values))
+        }
+    }
+
+    /// Rows describing the constraints a type carries, beyond its shape.
+    fn create_constraint_rows(&self, schema: &Schema) -> Vec<(&'static str, String)> {
+        let mut rows = vec![];
+
+        let mut push_some = |key, value: Option<String>| {
+            if let Some(value) = value {
+                rows.push((key, value));
+            }
+        };
+
+        match &schema.ty {
+            SchemaType::Array(array) => {
+                push_some("Min items", array.min_length.map(|v| code(v.to_string())));
+                push_some("Max items", array.max_length.map(|v| code(v.to_string())));
+                push_some("Unique items", array.unique.map(|v| code(v.to_string())));
+            }
+            SchemaType::Float(float) => {
+                push_some("Format", float.format.as_ref().map(code));
+                push_some("Minimum", float.min.map(|v| code(v.to_string())));
+                push_some(
+                    "Exclusive minimum",
+                    float.min_exclusive.map(|v| code(v.to_string())),
+                );
+                push_some("Maximum", float.max.map(|v| code(v.to_string())));
+                push_some(
+                    "Exclusive maximum",
+                    float.max_exclusive.map(|v| code(v.to_string())),
+                );
+                push_some(
+                    "Multiple of",
+                    float.multiple_of.map(|v| code(v.to_string())),
+                );
+            }
+            SchemaType::Integer(integer) => {
+                push_some("Format", integer.format.as_ref().map(code));
+                push_some("Minimum", integer.min.map(|v| code(v.to_string())));
+                push_some(
+                    "Exclusive minimum",
+                    integer.min_exclusive.map(|v| code(v.to_string())),
+                );
+                push_some("Maximum", integer.max.map(|v| code(v.to_string())));
+                push_some(
+                    "Exclusive maximum",
+                    integer.max_exclusive.map(|v| code(v.to_string())),
+                );
+                push_some(
+                    "Multiple of",
+                    integer.multiple_of.map(|v| code(v.to_string())),
+                );
+            }
+            SchemaType::Object(object) => {
+                push_some(
+                    "Min properties",
+                    object.min_length.map(|v| code(v.to_string())),
+                );
+                push_some(
+                    "Max properties",
+                    object.max_length.map(|v| code(v.to_string())),
+                );
+            }
+            SchemaType::String(string) => {
+                push_some("Format", string.format.as_ref().map(code));
+                push_some("Pattern", string.pattern.as_ref().map(code));
+                push_some("Min length", string.min_length.map(|v| code(v.to_string())));
+                push_some("Max length", string.max_length.map(|v| code(v.to_string())));
+            }
+            _ => {}
+        };
+
+        rows
+    }
+
+    /// Render the table describing a field's type: its shape, default,
+    /// accepted values, and constraints.
+    fn render_field_table(&mut self, field: &SchemaField) -> RenderResult {
+        let schema = strip_null(&field.schema);
+        let expr = self.render_schema(&schema)?;
+
+        let mut rows = vec![("Type", self.render_type_expression(&expr))];
+
+        if let Some(default) = field.schema.get_default() {
+            rows.push(("Default", code(lit_to_string(default))));
+        }
+
+        if let Some(values) = self.render_enum_values(&schema) {
+            rows.push(("Values", values));
+        }
+
+        rows.extend(self.create_constraint_rows(&schema));
+
+        if !self.options.exclude_aliases && !field.aliases.is_empty() {
+            rows.push(("Aliases", code_list(&field.aliases)));
+        }
+
+        if let Some(env_var) = &field.env_var
+            && !env_var.is_empty()
+        {
+            rows.push(("Environment variable", code(env_var)));
+        }
+
+        Ok(self.render_table(rows))
+    }
+
+    fn render_property(&mut self, name: &str, field: &SchemaField) -> RenderResult {
+        let mut out = vec![format!("### {}", code(name))];
+        let mut tags = vec![];
+
+        let nullable = field.nullable || field.schema.is_nullable();
+
+        if field.optional {
+            tags.push("**Optional**".to_owned());
+        }
+        // A missing `Option` deserializes as `None`, and a flattened field has
+        // no key of its own, so neither can be required
+        else if self.options.mark_struct_fields_required && !nullable && !field.flatten {
+            tags.push("**Required**".to_owned());
+        }
+
+        if nullable {
+            tags.push("**Nullable**".to_owned());
+        }
+
+        if let Some(deprecated) = &field.deprecated {
+            tags.push(self.deprecated_tag(deprecated));
+        }
+
+        if field.read_only {
+            tags.push("**Read only**".to_owned());
+        }
+
+        if field.write_only {
+            tags.push("**Write only**".to_owned());
+        }
+
+        if field.flatten {
+            tags.push("**Flattened**".to_owned());
+        }
+
+        if let Some(tags) = self.render_tags(tags) {
+            out.push(tags);
+        }
+
+        if let Some(comment) = &field.comment {
+            out.push(clean_comment(comment));
+        }
+
+        out.push(self.render_field_table(field)?);
+
+        Ok(out.join("\n\n"))
+    }
+
+    fn render_struct_page(&mut self, structure: &StructType) -> RenderResult {
+        let mut out = vec![];
+
+        for (name, field) in structure.sorted_fields() {
+            if field.hidden {
+                continue;
+            }
+
+            out.push(self.render_property(name, field)?);
+        }
+
+        if out.is_empty() {
+            return Ok(String::new());
+        }
+
+        out.insert(0, "## Properties".to_owned());
+
+        Ok(out.join("\n\n"))
+    }
+
+    fn render_variant(
+        &mut self,
+        name: &str,
+        variant: &SchemaField,
+        is_default: bool,
+    ) -> RenderResult {
+        let mut out = vec![format!("### {}", code(name))];
+        let mut tags = vec![];
+
+        if is_default {
+            tags.push("**Default**".to_owned());
+        }
+
+        if let Some(deprecated) = variant
+            .deprecated
+            .as_ref()
+            .or(variant.schema.deprecated.as_ref())
+        {
+            tags.push(self.deprecated_tag(deprecated));
+        }
+
+        if let Some(tags) = self.render_tags(tags) {
+            out.push(tags);
+        }
+
+        if let Some(comment) = variant
+            .comment
+            .as_ref()
+            .or(variant.schema.description.as_ref())
+        {
+            out.push(clean_comment(comment));
+        }
+
+        // A unit variant is its value, while a fallback variant accepts a type
+        let key = if matches!(variant.schema.ty, SchemaType::Literal(_)) {
+            "Value"
+        } else {
+            "Type"
+        };
+
+        let expr = self.render_schema(&variant.schema)?;
+        let mut rows = vec![(key, self.render_type_expression(&expr))];
+
+        rows.extend(self.create_constraint_rows(&variant.schema));
+
+        out.push(self.render_table(rows));
+
+        Ok(out.join("\n\n"))
+    }
+
+    fn render_enum_page(&mut self, enu: &EnumType) -> RenderResult {
+        let mut out = vec![];
+
+        match &enu.variants {
+            Some(variants) => {
+                for (index, (name, variant)) in variants.iter().enumerate() {
+                    if variant.hidden {
+                        continue;
+                    }
+
+                    out.push(self.render_variant(
+                        name,
+                        variant,
+                        enu.default_index == Some(index),
+                    )?);
+                }
+            }
+            None => {
+                for (index, value) in enu.values.iter().enumerate() {
+                    let name = match value {
+                        LiteralValue::String(inner) => inner.to_owned(),
+                        other => other.to_string(),
+                    };
+
+                    out.push(self.render_variant(
+                        &name,
+                        &SchemaField::new(Schema::literal_value(value.clone())),
+                        enu.default_index == Some(index),
+                    )?);
+                }
+            }
+        };
+
+        if out.is_empty() {
+            return Ok(String::new());
+        }
+
+        out.insert(0, "## Variants".to_owned());
+
+        Ok(out.join("\n\n"))
+    }
+
+    /// A page for a union, such as an untagged enum, which lists each variant.
+    /// Variants have no names of their own, so each is headed by its type.
+    fn render_union_page(&mut self, uni: &UnionType) -> RenderResult {
+        let mut out = vec![];
+
+        for (index, variant) in uni.variants_types.iter().enumerate() {
+            // Reported through the page's nullable tag instead
+            if variant.is_null() {
+                continue;
+            }
+
+            let expr = self.render_schema(variant)?;
+            let mut section = vec![format!("### {}", code(expr.to_string()))];
+            let mut tags = vec![];
+
+            if uni.default_index == Some(index) {
+                tags.push("**Default**".to_owned());
+            }
+
+            if let Some(deprecated) = &variant.deprecated {
+                tags.push(self.deprecated_tag(deprecated));
+            }
+
+            if let Some(tags) = self.render_tags(tags) {
+                section.push(tags);
+            }
+
+            if let Some(description) = &variant.description {
+                section.push(clean_comment(description));
+            }
+
+            let mut rows = vec![("Type", self.render_type_expression(&expr))];
+
+            if let Some(default) = variant.get_default() {
+                rows.push(("Default", code(lit_to_string(default))));
+            }
+
+            if let Some(values) = self.render_enum_values(variant) {
+                rows.push(("Values", values));
+            }
+
+            rows.extend(self.create_constraint_rows(variant));
+
+            section.push(self.render_table(rows));
+
+            out.push(section.join("\n\n"));
+        }
+
+        if out.is_empty() {
+            return Ok(String::new());
+        }
+
+        out.insert(0, "## Variants".to_owned());
+
+        Ok(out.join("\n\n"))
+    }
+
+    /// A page for a type that is neither a struct, an enum, nor a union, such
+    /// as an aliased scalar, which describes the type as a whole.
+    fn render_type_page(&mut self, schema: &Schema) -> RenderResult {
+        let stripped = strip_null(schema);
+        let expr = self.render_schema_without_reference(&stripped)?;
+
+        let mut rows = vec![("Type", self.render_type_expression(&expr))];
+
+        if let Some(default) = schema.get_default() {
+            rows.push(("Default", code(lit_to_string(default))));
+        }
+
+        if let Some(values) = self.render_enum_values(&stripped) {
+            rows.push(("Values", values));
+        }
+
+        rows.extend(self.create_constraint_rows(&stripped));
+
+        Ok(format!("## Type\n\n{}", self.render_table(rows)))
+    }
+
+    fn render_page(&mut self, name: &str, schema: &Schema) -> RenderResult {
+        let mut out = vec![format!("---\ntitle: {name}\n---")];
+        let mut tags = vec![];
+
+        if let Some(deprecated) = &schema.deprecated {
+            tags.push(self.deprecated_tag(deprecated));
+        }
+
+        if schema.nullable || schema.is_nullable() {
+            tags.push("**Nullable**".to_owned());
+        }
+
+        if let Some(tags) = self.render_tags(tags) {
+            out.push(tags);
+        }
+
+        if let Some(description) = &schema.description {
+            out.push(clean_comment(description));
+        }
+
+        let body = match &schema.ty {
+            SchemaType::Struct(inner) => self.render_struct_page(inner)?,
+            SchemaType::Enum(inner) => self.render_enum_page(inner)?,
+            SchemaType::Union(inner) => self.render_union_page(inner)?,
+            _ => self.render_type_page(schema)?,
+        };
+
+        if !body.is_empty() {
+            out.push(body);
+        }
+
+        // A recursive type links to itself, which is not a reference to
+        // another page
+        self.linked.remove(name);
+
+        if !self.linked.is_empty() {
+            let links = self
+                .linked
+                .iter()
+                .map(|name| format!("- [{name}]({})", self.create_link(name)))
+                .collect::<Vec<_>>();
+
+            out.push(format!("## References\n\n{}", links.join("\n")));
+        }
+
+        Ok(out.join("\n\n"))
+    }
+}
+
+impl SchemaRenderer<TypeExpression> for ApiDocsRenderer {
+    fn is_reference(&self, name: &str) -> bool {
+        self.references.contains(name)
+    }
+
+    fn render_array(
+        &mut self,
+        array: &ArrayType,
+        _schema: &Schema,
+    ) -> RenderResult<TypeExpression> {
+        let mut expr = self.render_schema(&array.items_type)?;
+
+        if expr.is_union() {
+            expr = expr.parenthesize();
+        }
+
+        expr.push_code("[]");
+
+        Ok(expr)
+    }
+
+    fn render_boolean(
+        &mut self,
+        _boolean: &BooleanType,
+        _schema: &Schema,
+    ) -> RenderResult<TypeExpression> {
+        Ok(TypeExpression::code("boolean"))
+    }
+
+    fn render_enum(&mut self, enu: &EnumType, schema: &Schema) -> RenderResult<TypeExpression> {
+        // Map using variants instead of values (when available),
+        // so that the fallback variant is included
+        let variants_types = match &enu.variants {
+            Some(variants) => variants
+                .values()
+                .filter(|variant| !variant.hidden)
+                .map(|variant| variant.schema.clone())
+                .collect::<Vec<_>>(),
+            None => enu
+                .values
+                .iter()
+                .map(|value| Schema::literal_value(value.clone()))
+                .collect(),
+        };
+
+        self.render_union(&UnionType::new_any(variants_types), schema)
+    }
+
+    fn render_float(
+        &mut self,
+        _float: &FloatType,
+        _schema: &Schema,
+    ) -> RenderResult<TypeExpression> {
+        Ok(TypeExpression::code("number"))
+    }
+
+    fn render_integer(
+        &mut self,
+        _integer: &IntegerType,
+        _schema: &Schema,
+    ) -> RenderResult<TypeExpression> {
+        Ok(TypeExpression::code("number"))
+    }
+
+    fn render_literal(
+        &mut self,
+        literal: &LiteralType,
+        _schema: &Schema,
+    ) -> RenderResult<TypeExpression> {
+        Ok(TypeExpression::code(lit_to_string(&literal.value)))
+    }
+
+    fn render_null(&mut self, _schema: &Schema) -> RenderResult<TypeExpression> {
+        Ok(TypeExpression::code("null"))
+    }
+
+    fn render_object(
+        &mut self,
+        object: &ObjectType,
+        _schema: &Schema,
+    ) -> RenderResult<TypeExpression> {
+        let mut expr = TypeExpression::code("Record<");
+        expr.extend(self.render_schema(&object.key_type)?);
+        expr.push_code(", ");
+        expr.extend(self.render_schema(&object.value_type)?);
+        expr.push_code(">");
+
+        Ok(expr)
+    }
+
+    fn render_reference(
+        &mut self,
+        reference: &str,
+        _schema: &Schema,
+    ) -> RenderResult<TypeExpression> {
+        self.linked.insert(reference.to_owned());
+
+        Ok(TypeExpression::reference(reference))
+    }
+
+    fn render_string(
+        &mut self,
+        _string: &StringType,
+        _schema: &Schema,
+    ) -> RenderResult<TypeExpression> {
+        Ok(TypeExpression::code("string"))
+    }
+
+    fn render_struct(
+        &mut self,
+        structure: &StructType,
+        _schema: &Schema,
+    ) -> RenderResult<TypeExpression> {
+        let mut fields = vec![];
+
+        for (name, field) in structure.sorted_fields() {
+            if field.hidden {
+                continue;
+            }
+
+            let mut expr =
+                TypeExpression::code(format!("{name}{}: ", if field.optional { "?" } else { "" }));
+            expr.extend(self.render_schema(&field.schema)?);
+
+            fields.push(expr);
+        }
+
+        if fields.is_empty() {
+            return Ok(TypeExpression::code("{}"));
+        }
+
+        let mut expr = TypeExpression::code("{ ");
+        expr.extend(TypeExpression::join(fields, ", "));
+        expr.push_code(" }");
+
+        Ok(expr)
+    }
+
+    fn render_tuple(
+        &mut self,
+        tuple: &TupleType,
+        _schema: &Schema,
+    ) -> RenderResult<TypeExpression> {
+        let mut items = vec![];
+
+        for item in &tuple.items_types {
+            items.push(self.render_schema(item)?);
+        }
+
+        let mut expr = TypeExpression::code("[");
+        expr.extend(TypeExpression::join(items, ", "));
+        expr.push_code("]");
+
+        Ok(expr)
+    }
+
+    fn render_union(&mut self, uni: &UnionType, _schema: &Schema) -> RenderResult<TypeExpression> {
+        let mut items = vec![];
+
+        for item in &uni.variants_types {
+            items.push(self.render_schema(item)?);
+        }
+
+        let mut expr = TypeExpression::join(items, " | ");
+        expr.is_union = uni.variants_types.len() > 1;
+
+        Ok(expr)
+    }
+
+    fn render_unknown(&mut self, _schema: &Schema) -> RenderResult<TypeExpression> {
+        Ok(TypeExpression::code("unknown"))
+    }
+
+    fn render(&mut self, schemas: IndexMap<String, Schema>) -> RenderResult {
+        // The last schema in the generator is the page to render, and every
+        // other schema is a type it may link to
+        let Some((name, schema)) = schemas.last() else {
+            return Err(miette!(
+                "At least one type must be added to the generator to render API docs."
+            ));
+        };
+
+        self.references = HashSet::from_iter(schemas.keys().cloned());
+        self.linked = BTreeSet::default();
+
+        self.render_page(name, schema)
+    }
+}

--- a/crates/schematic/src/schema/renderers/api_docs.rs
+++ b/crates/schematic/src/schema/renderers/api_docs.rs
@@ -90,6 +90,10 @@ pub struct ApiDocsOptions {
     /// Exclude field aliases from being rendered.
     pub exclude_aliases: bool,
 
+    /// Render an index of all properties or variants, linking to each
+    /// section, ahead of the sections themselves.
+    pub include_index: bool,
+
     /// File extension appended to the name of a referenced type when linking
     /// to its page, such as `.md`. Set to an empty string to link to the bare
     /// name, for documentation tools that route on the file name.
@@ -112,6 +116,7 @@ impl Default for ApiDocsOptions {
     fn default() -> Self {
         Self {
             exclude_aliases: false,
+            include_index: true,
             link_extension: ".md".into(),
             mark_struct_fields_required: true,
             render_description: Box::new(default_description_renderer),
@@ -248,6 +253,38 @@ where
     V: AsRef<str>,
 {
     values.into_iter().map(code).collect::<Vec<_>>().join(", ")
+}
+
+/// The anchor a heading is linked by, following the GitHub convention that
+/// most renderers share: lowercased, punctuation removed, spaces hyphenated.
+fn anchor(heading: &str) -> String {
+    heading
+        .to_lowercase()
+        .chars()
+        .filter(|ch| ch.is_alphanumeric() || *ch == ' ' || *ch == '-' || *ch == '_')
+        .map(|ch| if ch == ' ' { '-' } else { ch })
+        .collect()
+}
+
+/// The first paragraph of a description on a single line, for a table cell.
+fn summarize(description: &str) -> String {
+    description
+        .trim()
+        .split("\n\n")
+        .next()
+        .unwrap_or_default()
+        .lines()
+        .map(|line| line.trim())
+        .collect::<Vec<_>>()
+        .join(" ")
+        .replace('|', "\\|")
+}
+
+/// A row of the index that heads a page.
+struct IndexRow {
+    name: String,
+    ty: String,
+    description: Option<String>,
 }
 
 /// Remove `null` from a nullable schema, so that nullability is reported once
@@ -479,13 +516,49 @@ impl ApiDocsRenderer {
         rows
     }
 
+    /// Render the index heading a page, one row per section, each linking to
+    /// the section it summarizes.
+    fn render_index(&self, kind: &str, rows: &[IndexRow]) -> Option<String> {
+        if !self.options.include_index || rows.is_empty() {
+            return None;
+        }
+
+        let mut out = vec![
+            "## Index".to_owned(),
+            String::new(),
+            format!("| {kind} | Type | Description |"),
+            "| --- | --- | --- |".to_owned(),
+        ];
+
+        for row in rows {
+            out.push(format!(
+                "| [{}](#{}) | {} | {} |",
+                code(&row.name),
+                anchor(&row.name),
+                row.ty,
+                row.description
+                    .as_deref()
+                    .map(summarize)
+                    .unwrap_or_default(),
+            ));
+        }
+
+        Some(out.join("\n"))
+    }
+
+    /// Render a field's type, without the `null` its nullable tag reports.
+    fn render_field_type(&mut self, field: &SchemaField) -> RenderResult {
+        let schema = strip_null(&field.schema);
+        let expr = self.render_schema(&schema)?;
+
+        Ok(self.render_type_expression(&expr))
+    }
+
     /// Render the table describing a field's type: its shape, default,
     /// accepted values, and constraints.
     fn render_field_table(&mut self, field: &SchemaField) -> RenderResult {
         let schema = strip_null(&field.schema);
-        let expr = self.render_schema(&schema)?;
-
-        let mut rows = vec![("Type", self.render_type_expression(&expr))];
+        let mut rows = vec![("Type", self.render_field_type(field)?)];
 
         if let Some(default) = field.schema.get_default() {
             rows.push(("Default", code(lit_to_string(default))));
@@ -563,23 +636,49 @@ impl ApiDocsRenderer {
     }
 
     fn render_struct_page(&mut self, structure: &StructType) -> RenderResult {
-        let mut out = vec![];
+        let mut index = vec![];
+        let mut sections = vec![];
 
         for (name, field) in structure.sorted_fields() {
             if field.hidden {
                 continue;
             }
 
-            out.push(self.render_property(name, field)?);
+            index.push(IndexRow {
+                name: name.to_owned(),
+                ty: self.render_field_type(field)?,
+                description: field.comment.clone(),
+            });
+
+            sections.push(self.render_property(name, field)?);
         }
 
-        if out.is_empty() {
-            return Ok(String::new());
+        Ok(self.assemble_sections("Property", "## Properties", index, sections))
+    }
+
+    /// Assemble a page body from its index and sections, which is empty when
+    /// there are no sections to list.
+    fn assemble_sections(
+        &self,
+        kind: &str,
+        heading: &str,
+        index: Vec<IndexRow>,
+        sections: Vec<String>,
+    ) -> String {
+        if sections.is_empty() {
+            return String::new();
         }
 
-        out.insert(0, "## Properties".to_owned());
+        let mut out = vec![];
 
-        Ok(out.join("\n\n"))
+        if let Some(index) = self.render_index(kind, &index) {
+            out.push(index);
+        }
+
+        out.push(heading.to_owned());
+        out.extend(sections);
+
+        out.join("\n\n")
     }
 
     fn render_variant(
@@ -634,68 +733,84 @@ impl ApiDocsRenderer {
     }
 
     fn render_enum_page(&mut self, enu: &EnumType) -> RenderResult {
-        let mut out = vec![];
-
-        match &enu.variants {
-            Some(variants) => {
-                for (index, (name, variant)) in variants.iter().enumerate() {
-                    if variant.hidden {
-                        continue;
-                    }
-
-                    out.push(self.render_variant(
-                        name,
-                        variant,
-                        enu.default_index == Some(index),
-                    )?);
-                }
-            }
-            None => {
-                for (index, value) in enu.values.iter().enumerate() {
+        // Variants without names are their values
+        let variants = match &enu.variants {
+            Some(variants) => variants
+                .iter()
+                .map(|(name, variant)| (name.to_owned(), (**variant).clone()))
+                .collect::<Vec<_>>(),
+            None => enu
+                .values
+                .iter()
+                .map(|value| {
                     let name = match value {
                         LiteralValue::String(inner) => inner.to_owned(),
                         other => other.to_string(),
                     };
 
-                    out.push(self.render_variant(
-                        &name,
-                        &SchemaField::new(Schema::literal_value(value.clone())),
-                        enu.default_index == Some(index),
-                    )?);
-                }
-            }
+                    (name, SchemaField::new(Schema::literal_value(value.clone())))
+                })
+                .collect(),
         };
 
-        if out.is_empty() {
-            return Ok(String::new());
+        let mut index = vec![];
+        let mut sections = vec![];
+
+        for (position, (name, variant)) in variants.iter().enumerate() {
+            if variant.hidden {
+                continue;
+            }
+
+            let expr = self.render_schema(&variant.schema)?;
+
+            index.push(IndexRow {
+                name: name.to_owned(),
+                ty: self.render_type_expression(&expr),
+                description: variant
+                    .comment
+                    .clone()
+                    .or_else(|| variant.schema.description.clone()),
+            });
+
+            sections.push(self.render_variant(
+                name,
+                variant,
+                enu.default_index == Some(position),
+            )?);
         }
 
-        out.insert(0, "## Variants".to_owned());
-
-        Ok(out.join("\n\n"))
+        Ok(self.assemble_sections("Variant", "## Variants", index, sections))
     }
 
     /// A page for a union, such as an untagged enum, which lists each variant.
     /// A variant is headed by its name when the union was derived from an
     /// enum, and by its type otherwise.
     fn render_union_page(&mut self, uni: &UnionType) -> RenderResult {
-        let mut out = vec![];
+        let mut index = vec![];
+        let mut sections = vec![];
 
-        for (index, variant) in uni.variants_types.iter().enumerate() {
+        for (position, variant) in uni.variants_types.iter().enumerate() {
             // Reported through the page's nullable tag instead
             if variant.is_null() {
                 continue;
             }
 
             let expr = self.render_schema(variant)?;
-            let heading = match uni.get_variant_name(index) {
+            let heading = match uni.get_variant_name(position) {
                 Some(name) => name.to_owned(),
                 None => expr.to_string(),
             };
+
+            index.push(IndexRow {
+                name: heading.clone(),
+                ty: self.render_type_expression(&expr),
+                description: variant.description.clone(),
+            });
+
             let mut section = vec![format!("### {}", code(heading))];
             let mut tags = vec![];
 
-            if uni.default_index == Some(index) {
+            if uni.default_index == Some(position) {
                 tags.push(ApiDocsTag::Default);
             }
 
@@ -729,16 +844,10 @@ impl ApiDocsRenderer {
 
             section.push(self.render_table(rows));
 
-            out.push(section.join("\n\n"));
+            sections.push(section.join("\n\n"));
         }
 
-        if out.is_empty() {
-            return Ok(String::new());
-        }
-
-        out.insert(0, "## Variants".to_owned());
-
-        Ok(out.join("\n\n"))
+        Ok(self.assemble_sections("Variant", "## Variants", index, sections))
     }
 
     /// A page for a type that is neither a struct, an enum, nor a union, such

--- a/crates/schematic/src/schema/renderers/api_docs.rs
+++ b/crates/schematic/src/schema/renderers/api_docs.rs
@@ -57,6 +57,18 @@ pub type ApiDocsTagsRenderer = Box<dyn Fn(&[ApiDocsTag]) -> String>;
 /// from the doc comment as written. An empty result omits the description.
 pub type ApiDocsDescriptionRenderer = Box<dyn Fn(&str) -> String>;
 
+/// Renders a link to a referenced type's page, from the type name, as a
+/// complete markdown link including its label. Used wherever a type is
+/// linked: inline in a type expression, and in the references list.
+pub type ApiDocsLinkRenderer = Box<dyn Fn(&str) -> String>;
+
+/// The default link renderer, which labels the link with the type name as
+/// inline code, and links to a markdown file named after the type in the
+/// same directory, such as `` [`Name`](./Name.md) ``.
+pub fn default_link_renderer(name: &str) -> String {
+    format!("[{}](./{name}.md)", code(name))
+}
+
 /// The default tags renderer, which renders a block quote of bold labels
 /// separated by a middle dot, such as `> **Required** · **Nullable**`. A
 /// deprecation message follows its label in parentheses.
@@ -114,13 +126,12 @@ pub struct ApiDocsOptions {
     /// section, ahead of the sections themselves.
     pub include_index: bool,
 
-    /// File extension appended to the name of a referenced type when linking
-    /// to its page, such as `.md`. Set to an empty string to link to the bare
-    /// name, for documentation tools that route on the file name.
-    pub link_extension: String,
-
     /// Tag all non-optional struct fields as required.
     pub mark_struct_fields_required: bool,
+
+    /// Renders a link to a referenced type's page, label included, from the
+    /// type name. Defaults to [`default_link_renderer`].
+    pub render_link: ApiDocsLinkRenderer,
 
     /// Renders the description of a type, property, or variant. Receives the
     /// doc comment as written. Defaults to [`default_description_renderer`].
@@ -139,8 +150,8 @@ impl Default for ApiDocsOptions {
             exclude_aliases: false,
             frontmatter: BTreeMap::new(),
             include_index: true,
-            link_extension: ".md".into(),
             mark_struct_fields_required: true,
+            render_link: Box::new(default_link_renderer),
             render_description: Box::new(default_description_renderer),
             render_tags: Box::new(default_tags_renderer),
         }
@@ -374,7 +385,7 @@ impl ApiDocsRenderer {
     }
 
     fn create_link(&self, name: &str) -> String {
-        format!("./{name}{}", self.options.link_extension)
+        (self.options.render_link)(name)
     }
 
     fn render_type_expression(&self, expr: &TypeExpression) -> String {
@@ -383,9 +394,7 @@ impl ApiDocsRenderer {
         for part in &expr.parts {
             match part {
                 TypePart::Code(value) => out.push_str(&code(value)),
-                TypePart::Reference(name) => {
-                    out.push_str(&format!("[{}]({})", code(name), self.create_link(name)));
-                }
+                TypePart::Reference(name) => out.push_str(&self.create_link(name)),
             }
         }
 
@@ -1024,7 +1033,7 @@ impl ApiDocsRenderer {
             let links = self
                 .linked
                 .iter()
-                .map(|name| format!("- [{name}]({})", self.create_link(name)))
+                .map(|name| format!("- {}", self.create_link(name)))
                 .collect::<Vec<_>>();
 
             out.push(format!("## References\n\n{}", links.join("\n")));

--- a/crates/schematic/src/schema/renderers/api_docs.rs
+++ b/crates/schematic/src/schema/renderers/api_docs.rs
@@ -72,6 +72,24 @@ pub fn default_link_renderer(name: &str) -> String {
     format!("[{}](./{name}.md)", code(name))
 }
 
+/// Renders the fragment a section is linked by, from the text of its
+/// heading, such as the property or variant name. The result follows the
+/// `#` in an index link, so it must match the id the documentation tool
+/// gives the heading.
+pub type ApiDocsAnchorRenderer = Box<dyn Fn(&str) -> String>;
+
+/// The default anchor renderer, which follows the GitHub convention that
+/// most documentation tools share: lowercased, punctuation removed, and
+/// spaces hyphenated, so `` `expand_array` `` becomes `expand_array`.
+pub fn default_anchor_renderer(heading: &str) -> String {
+    heading
+        .to_lowercase()
+        .chars()
+        .filter(|ch| ch.is_alphanumeric() || *ch == ' ' || *ch == '-' || *ch == '_')
+        .map(|ch| if ch == ' ' { '-' } else { ch })
+        .collect()
+}
+
 /// The default tags renderer, which renders a block quote of bold labels
 /// separated by a middle dot, such as `> **Required** · **Nullable**`. A
 /// deprecation message follows its label in parentheses.
@@ -136,6 +154,10 @@ pub struct ApiDocsOptions {
     /// Tag all non-optional struct fields as required.
     pub mark_struct_fields_required: bool,
 
+    /// Renders the fragment an index entry links its section by, from the
+    /// heading text. Defaults to [`default_anchor_renderer`].
+    pub render_anchor: ApiDocsAnchorRenderer,
+
     /// Renders a link to a referenced type's page, label included, from the
     /// type name. Defaults to [`default_link_renderer`].
     pub render_link: ApiDocsLinkRenderer,
@@ -159,6 +181,7 @@ impl Default for ApiDocsOptions {
             include_index: true,
             index_page: Some("index.md".into()),
             mark_struct_fields_required: true,
+            render_anchor: Box::new(default_anchor_renderer),
             render_link: Box::new(default_link_renderer),
             render_description: Box::new(default_description_renderer),
             render_tags: Box::new(default_tags_renderer),
@@ -314,17 +337,6 @@ where
     V: AsRef<str>,
 {
     values.into_iter().map(code).collect::<Vec<_>>().join(", ")
-}
-
-/// The anchor a heading is linked by, following the GitHub convention that
-/// most renderers share: lowercased, punctuation removed, spaces hyphenated.
-fn anchor(heading: &str) -> String {
-    heading
-        .to_lowercase()
-        .chars()
-        .filter(|ch| ch.is_alphanumeric() || *ch == ' ' || *ch == '-' || *ch == '_')
-        .map(|ch| if ch == ' ' { '-' } else { ch })
-        .collect()
 }
 
 /// The first paragraph of a description on a single line, for a table cell.
@@ -752,7 +764,7 @@ impl ApiDocsRenderer {
             out.push(format!(
                 "| [{}](#{}) | {} | {} |",
                 code(&row.name),
-                anchor(&row.name),
+                (self.options.render_anchor)(&row.name),
                 row.ty,
                 row.description
                     .as_deref()

--- a/crates/schematic/src/schema/renderers/api_docs.rs
+++ b/crates/schematic/src/schema/renderers/api_docs.rs
@@ -6,6 +6,85 @@ use std::borrow::Cow;
 use std::collections::{BTreeSet, HashSet};
 use std::fmt;
 
+/// A tag describing how a type, property, or variant may be provided.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ApiDocsTag {
+    /// The default variant of an enum or union.
+    Default,
+    /// Deprecated, with the deprecation message when one was given.
+    Deprecated(Option<String>),
+    /// A property whose keys are flattened into its parent.
+    Flattened,
+    /// Accepts `null`.
+    Nullable,
+    /// A property that may be omitted.
+    Optional,
+    /// A property that must be provided.
+    Required,
+    /// A property that is only serialized, never deserialized.
+    ReadOnly,
+    /// A property that is only deserialized, never serialized.
+    WriteOnly,
+}
+
+impl ApiDocsTag {
+    /// The human readable label of the tag.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Default => "Default",
+            Self::Deprecated(_) => "Deprecated",
+            Self::Flattened => "Flattened",
+            Self::Nullable => "Nullable",
+            Self::Optional => "Optional",
+            Self::Required => "Required",
+            Self::ReadOnly => "Read only",
+            Self::WriteOnly => "Write only",
+        }
+    }
+}
+
+impl fmt::Display for ApiDocsTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.label())
+    }
+}
+
+/// Renders the tags of a type, property, or variant to markdown. Only called
+/// with at least one tag, and an empty result omits the tags entirely.
+pub type ApiDocsTagsRenderer = Box<dyn Fn(&[ApiDocsTag]) -> String>;
+
+/// Renders the description of a type, property, or variant to markdown,
+/// from the doc comment as written. An empty result omits the description.
+pub type ApiDocsDescriptionRenderer = Box<dyn Fn(&str) -> String>;
+
+/// The default tags renderer, which renders a block quote of bold labels
+/// separated by a middle dot, such as `> **Required** · **Nullable**`. A
+/// deprecation message follows its label in parentheses.
+pub fn default_tags_renderer(tags: &[ApiDocsTag]) -> String {
+    let tags = tags
+        .iter()
+        .map(|tag| match tag {
+            ApiDocsTag::Deprecated(Some(message)) => {
+                format!("**{}** ({})", tag.label(), message.trim())
+            }
+            _ => format!("**{}**", tag.label()),
+        })
+        .collect::<Vec<_>>();
+
+    format!("> {}", tags.join(" · "))
+}
+
+/// The default description renderer, which keeps a description as written,
+/// so that paragraphs and lists survive, and only trims each line.
+pub fn default_description_renderer(description: &str) -> String {
+    description
+        .trim()
+        .lines()
+        .map(|line| line.trim())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Options to control the rendered API documentation.
 pub struct ApiDocsOptions {
     /// Exclude field aliases from being rendered.
@@ -18,6 +97,15 @@ pub struct ApiDocsOptions {
 
     /// Tag all non-optional struct fields as required.
     pub mark_struct_fields_required: bool,
+
+    /// Renders the description of a type, property, or variant. Receives the
+    /// doc comment as written. Defaults to [`default_description_renderer`].
+    pub render_description: ApiDocsDescriptionRenderer,
+
+    /// Renders the tags of a type, property, or variant. Receives the tags in
+    /// a fixed order, and is only called when there is at least one. Defaults
+    /// to [`default_tags_renderer`].
+    pub render_tags: ApiDocsTagsRenderer,
 }
 
 impl Default for ApiDocsOptions {
@@ -26,6 +114,8 @@ impl Default for ApiDocsOptions {
             exclude_aliases: false,
             link_extension: ".md".into(),
             mark_struct_fields_required: true,
+            render_description: Box::new(default_description_renderer),
+            render_tags: Box::new(default_tags_renderer),
         }
     }
 }
@@ -160,16 +250,6 @@ where
     values.into_iter().map(code).collect::<Vec<_>>().join(", ")
 }
 
-/// Keep a description as written, so that paragraphs and lists survive.
-fn clean_comment(comment: &str) -> String {
-    comment
-        .trim()
-        .lines()
-        .map(|line| line.trim())
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
 /// Remove `null` from a nullable schema, so that nullability is reported once
 /// through a tag instead of repeated in every type expression. A union that
 /// is left with a single variant collapses to that variant.
@@ -266,20 +346,22 @@ impl ApiDocsRenderer {
         out.join("\n")
     }
 
-    fn render_tags(&self, tags: Vec<String>) -> Option<String> {
+    fn render_tags(&self, tags: Vec<ApiDocsTag>) -> Option<String> {
         if tags.is_empty() {
             return None;
         }
 
-        Some(format!("> {}", tags.join(" · ")))
+        Some((self.options.render_tags)(&tags)).filter(|out| !out.is_empty())
     }
 
-    fn deprecated_tag(&self, message: &str) -> String {
-        if message.is_empty() {
-            "**Deprecated**".to_owned()
-        } else {
-            format!("**Deprecated** ({})", message.trim())
-        }
+    fn render_description(&self, description: &str) -> Option<String> {
+        Some((self.options.render_description)(description)).filter(|out| !out.is_empty())
+    }
+
+    fn deprecated_tag(&self, message: &str) -> ApiDocsTag {
+        let message = message.trim();
+
+        ApiDocsTag::Deprecated((!message.is_empty()).then(|| message.to_owned()))
     }
 
     /// Render the literal values an enumerable type accepts, for both
@@ -435,16 +517,16 @@ impl ApiDocsRenderer {
         let nullable = field.nullable || field.schema.is_nullable();
 
         if field.optional {
-            tags.push("**Optional**".to_owned());
+            tags.push(ApiDocsTag::Optional);
         }
         // A missing `Option` deserializes as `None`, and a flattened field has
         // no key of its own, so neither can be required
         else if self.options.mark_struct_fields_required && !nullable && !field.flatten {
-            tags.push("**Required**".to_owned());
+            tags.push(ApiDocsTag::Required);
         }
 
         if nullable {
-            tags.push("**Nullable**".to_owned());
+            tags.push(ApiDocsTag::Nullable);
         }
 
         if let Some(deprecated) = &field.deprecated {
@@ -452,23 +534,27 @@ impl ApiDocsRenderer {
         }
 
         if field.read_only {
-            tags.push("**Read only**".to_owned());
+            tags.push(ApiDocsTag::ReadOnly);
         }
 
         if field.write_only {
-            tags.push("**Write only**".to_owned());
+            tags.push(ApiDocsTag::WriteOnly);
         }
 
         if field.flatten {
-            tags.push("**Flattened**".to_owned());
+            tags.push(ApiDocsTag::Flattened);
         }
 
         if let Some(tags) = self.render_tags(tags) {
             out.push(tags);
         }
 
-        if let Some(comment) = &field.comment {
-            out.push(clean_comment(comment));
+        if let Some(comment) = field
+            .comment
+            .as_deref()
+            .and_then(|comment| self.render_description(comment))
+        {
+            out.push(comment);
         }
 
         out.push(self.render_field_table(field)?);
@@ -506,7 +592,7 @@ impl ApiDocsRenderer {
         let mut tags = vec![];
 
         if is_default {
-            tags.push("**Default**".to_owned());
+            tags.push(ApiDocsTag::Default);
         }
 
         if let Some(deprecated) = variant
@@ -523,10 +609,11 @@ impl ApiDocsRenderer {
 
         if let Some(comment) = variant
             .comment
-            .as_ref()
-            .or(variant.schema.description.as_ref())
+            .as_deref()
+            .or(variant.schema.description.as_deref())
+            .and_then(|comment| self.render_description(comment))
         {
-            out.push(clean_comment(comment));
+            out.push(comment);
         }
 
         // A unit variant is its value, while a fallback variant accepts a type
@@ -609,7 +696,7 @@ impl ApiDocsRenderer {
             let mut tags = vec![];
 
             if uni.default_index == Some(index) {
-                tags.push("**Default**".to_owned());
+                tags.push(ApiDocsTag::Default);
             }
 
             if let Some(deprecated) = &variant.deprecated {
@@ -620,8 +707,12 @@ impl ApiDocsRenderer {
                 section.push(tags);
             }
 
-            if let Some(description) = &variant.description {
-                section.push(clean_comment(description));
+            if let Some(description) = variant
+                .description
+                .as_deref()
+                .and_then(|description| self.render_description(description))
+            {
+                section.push(description);
             }
 
             let mut rows = vec![("Type", self.render_type_expression(&expr))];
@@ -680,15 +771,19 @@ impl ApiDocsRenderer {
         }
 
         if schema.nullable || schema.is_nullable() {
-            tags.push("**Nullable**".to_owned());
+            tags.push(ApiDocsTag::Nullable);
         }
 
         if let Some(tags) = self.render_tags(tags) {
             out.push(tags);
         }
 
-        if let Some(description) = &schema.description {
-            out.push(clean_comment(description));
+        if let Some(description) = schema
+            .description
+            .as_deref()
+            .and_then(|description| self.render_description(description))
+        {
+            out.push(description);
         }
 
         let body = match &schema.ty {

--- a/crates/schematic/src/schema/renderers/api_docs.rs
+++ b/crates/schematic/src/schema/renderers/api_docs.rs
@@ -1,10 +1,13 @@
+use crate::schema::SchemaGenerator;
 use crate::schema::{RenderResult, SchemaRenderer};
 use indexmap::IndexMap;
-use miette::miette;
+use miette::{IntoDiagnostic, miette};
 use schematic_types::*;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt;
+use std::fs;
+use std::path::Path;
 
 /// A tag describing how a type, property, or variant may be provided.
 #[derive(Clone, Debug, PartialEq)]
@@ -126,6 +129,10 @@ pub struct ApiDocsOptions {
     /// section, ahead of the sections themselves.
     pub include_index: bool,
 
+    /// File name of the index page listing every type, written by
+    /// [`ApiDocsRenderer::generate_all`]. `None` skips the page.
+    pub index_page: Option<String>,
+
     /// Tag all non-optional struct fields as required.
     pub mark_struct_fields_required: bool,
 
@@ -150,6 +157,7 @@ impl Default for ApiDocsOptions {
             exclude_aliases: false,
             frontmatter: BTreeMap::new(),
             include_index: true,
+            index_page: Some("index.md".into()),
             mark_struct_fields_required: true,
             render_link: Box::new(default_link_renderer),
             render_description: Box::new(default_description_renderer),
@@ -382,6 +390,101 @@ impl ApiDocsRenderer {
             references: HashSet::default(),
             linked: BTreeSet::default(),
         }
+    }
+
+    /// Render a page for every schema in the generator into the directory,
+    /// each named after its type with a `.md` extension, along with the
+    /// index page. Every schema is known to every page, so references link
+    /// to each other the same as they do through [`SchemaGenerator::generate`].
+    pub fn generate_all<P: AsRef<Path>>(
+        &mut self,
+        generator: &SchemaGenerator,
+        output_dir: P,
+    ) -> miette::Result<()> {
+        let output_dir = output_dir.as_ref();
+        let schemas = &generator.schemas;
+
+        if schemas.is_empty() {
+            return Err(miette!(
+                "At least one type must be added to the generator to render API docs."
+            ));
+        }
+
+        fs::create_dir_all(output_dir).into_diagnostic()?;
+
+        let write = |file_name: String, mut output: String| -> miette::Result<()> {
+            output.push('\n');
+            fs::write(output_dir.join(file_name), output).into_diagnostic()
+        };
+
+        for name in schemas.keys() {
+            write(format!("{name}.md"), self.render_page_of(schemas, name)?)?;
+        }
+
+        if let Some(index_page) = self.options.index_page.clone() {
+            write(index_page, self.render_index_page(schemas)?)?;
+        }
+
+        Ok(())
+    }
+
+    /// Render the index page, a table of every schema in name order that
+    /// links to its page, with its kind and the first paragraph of its
+    /// description.
+    pub fn render_index_page(&mut self, schemas: &IndexMap<String, Schema>) -> RenderResult {
+        self.references = HashSet::from_iter(schemas.keys().cloned());
+        self.linked = BTreeSet::default();
+
+        let mut out = vec![
+            self.render_frontmatter("Index"),
+            "## Types".to_owned(),
+            "| Type | Kind | Description |\n| --- | --- | --- |".to_owned(),
+        ];
+
+        let mut rows = vec![];
+
+        for (name, schema) in BTreeMap::from_iter(schemas) {
+            let kind = match &schema.ty {
+                SchemaType::Struct(_) => "Struct".to_owned(),
+                SchemaType::Enum(_) => "Enum".to_owned(),
+                SchemaType::Union(_) => "Union".to_owned(),
+                _ => {
+                    let expr = self.render_schema_without_reference(schema)?;
+
+                    self.render_type_expression(&expr)
+                }
+            };
+
+            rows.push(format!(
+                "| {} | {kind} | {} |",
+                self.create_link(name),
+                schema
+                    .description
+                    .as_deref()
+                    .map(summarize)
+                    .unwrap_or_default(),
+            ));
+        }
+
+        // Rows follow the header directly, with no blank line between
+        let table = out.pop().unwrap();
+        out.push(format!("{table}\n{}", rows.join("\n")));
+
+        Ok(out.join("\n\n"))
+    }
+
+    /// Render the page of one schema, with every schema known as a reference.
+    fn render_page_of(&mut self, schemas: &IndexMap<String, Schema>, name: &str) -> RenderResult {
+        let Some(schema) = schemas.get(name) else {
+            return Err(miette!(
+                "No schema named `{name}` has been added to the generator."
+            ));
+        };
+
+        self.references = HashSet::from_iter(schemas.keys().cloned());
+        self.linked = BTreeSet::default();
+
+        self.render_page(name, schema)
     }
 
     fn create_link(&self, name: &str) -> String {
@@ -1219,15 +1322,12 @@ impl SchemaRenderer<TypeExpression> for ApiDocsRenderer {
     fn render(&mut self, schemas: IndexMap<String, Schema>) -> RenderResult {
         // The last schema in the generator is the page to render, and every
         // other schema is a type it may link to
-        let Some((name, schema)) = schemas.last() else {
+        let Some(name) = schemas.keys().last().cloned() else {
             return Err(miette!(
                 "At least one type must be added to the generator to render API docs."
             ));
         };
 
-        self.references = HashSet::from_iter(schemas.keys().cloned());
-        self.linked = BTreeSet::default();
-
-        self.render_page(name, schema)
+        self.render_page_of(&schemas, &name)
     }
 }

--- a/crates/schematic/src/schema/renderers/mod.rs
+++ b/crates/schematic/src/schema/renderers/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "renderer_api_docs")]
+pub mod api_docs;
+
 #[cfg(feature = "renderer_json_schema")]
 pub mod json_schema;
 

--- a/crates/schematic/tests/generator_test.rs
+++ b/crates/schematic/tests/generator_test.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, deprecated)]
 
 use indexmap::{IndexMap, IndexSet};
-use schematic::schema::{SchemaGenerator, TemplateOptions};
+use schematic::schema::{IntegerKind, IntegerType, SchemaGenerator, StringType, TemplateOptions};
 use schematic::*;
 use starbase_sandbox::{assert_snapshot, create_empty_sandbox};
 use std::collections::HashMap;
@@ -144,6 +144,89 @@ struct TemplateConfig {
     expand_object: HashMap<String, AnotherConfig>,
     expand_object_primitive: HashMap<String, usize>,
     empty_object: HashMap<String, usize>,
+}
+
+/// A port number, constrained to the registered range.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+struct Port(u16);
+
+impl Schematic for Port {
+    fn build_schema(mut schema: SchemaBuilder) -> Schema {
+        schema.integer(IntegerType {
+            kind: IntegerKind::U16,
+            min: Some(1024),
+            max: Some(49151),
+            ..IntegerType::default()
+        })
+    }
+}
+
+/// A short identifier.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+struct Ident(String);
+
+impl Schematic for Ident {
+    fn build_schema(mut schema: SchemaBuilder) -> Schema {
+        schema.string(StringType {
+            max_length: Some(32),
+            min_length: Some(1),
+            pattern: Some("^[a-z][a-z0-9-]*$".into()),
+            ..StringType::default()
+        })
+    }
+}
+
+/// Either a list of targets, or a map of targets to paths.
+#[derive(Clone, Config)]
+#[serde(untagged)]
+enum Targets {
+    /// A list of targets.
+    List(Vec<String>),
+    /// A map of targets.
+    Map(HashMap<String, String>),
+}
+
+/// A config that exercises everything the docs can describe.
+///
+/// - With a list item.
+/// - And another.
+#[derive(Clone, Config)]
+struct DocsConfig {
+    /// A string with a default and aliases.
+    #[serde(alias = "label", alias = "title")]
+    #[setting(default = "hello", env = "DOCS_NAME")]
+    name: String,
+    /// A constrained integer.
+    port: Port,
+    /// A constrained string.
+    ident: Option<Ident>,
+    /// An optional nested config.
+    #[setting(nested)]
+    nested: Option<AnotherConfig>,
+    /// A list of nested configs.
+    #[setting(nested)]
+    list: Vec<AnotherConfig>,
+    /// A map of enums.
+    map: HashMap<String, BasicEnum>,
+    /// An enum, which carries its own default.
+    level: BasicEnum,
+    /// A deprecated field, use `name` instead.
+    #[deprecated = "Use `name` instead."]
+    old_name: Option<String>,
+    /// A tuple of values.
+    pair: (String, u32),
+    /// An inline struct.
+    duration: std::time::Duration,
+    /// A union of a list or a map.
+    #[setting(nested)]
+    targets: Targets,
+    /// A list of nullable enums.
+    nullable_items: Vec<Option<BasicEnum>>,
+    /// An optional boolean.
+    #[serde(default)]
+    boolean: bool,
+    #[setting(skip)]
+    hidden: String,
 }
 
 fn create_generator() -> SchemaGenerator {
@@ -535,6 +618,134 @@ mod typescript {
             indent_char: "  ".into(),
             ..TypeScriptOptions::default()
         }));
+    }
+}
+
+#[cfg(feature = "renderer_api_docs")]
+mod api_docs {
+    use super::*;
+    use schematic::schema::api_docs::*;
+
+    fn generate(generator: SchemaGenerator, options: ApiDocsOptions) -> String {
+        let sandbox = create_empty_sandbox();
+        let file = sandbox.path().join("docs.md");
+
+        generator
+            .generate(&file, ApiDocsRenderer::new(options))
+            .unwrap();
+
+        fs::read_to_string(file).unwrap()
+    }
+
+    #[test]
+    fn defaults() {
+        assert_snapshot!(generate(create_generator(), ApiDocsOptions::default()));
+    }
+
+    #[test]
+    fn partials() {
+        let mut generator = create_generator();
+        generator.add::<PartialGenConfig>();
+
+        assert_snapshot!(generate(generator, ApiDocsOptions::default()));
+    }
+
+    #[test]
+    fn all_field_shapes() {
+        let mut generator = SchemaGenerator::default();
+        generator.add::<DocsConfig>();
+
+        assert_snapshot!(generate(generator, ApiDocsOptions::default()));
+    }
+
+    #[test]
+    fn template_config() {
+        assert_snapshot!(generate(
+            create_template_generator(),
+            ApiDocsOptions::default()
+        ));
+    }
+
+    #[test]
+    fn unit_enum() {
+        let mut generator = SchemaGenerator::default();
+        generator.add::<BasicEnum>();
+
+        assert_snapshot!(generate(generator, ApiDocsOptions::default()));
+    }
+
+    #[test]
+    fn fallback_enum() {
+        let mut generator = SchemaGenerator::default();
+        generator.add::<FallbackEnum>();
+
+        assert_snapshot!(generate(generator, ApiDocsOptions::default()));
+    }
+
+    #[test]
+    fn union() {
+        let mut generator = SchemaGenerator::default();
+        generator.add::<Targets>();
+
+        assert_snapshot!(generate(generator, ApiDocsOptions::default()));
+    }
+
+    // A type nested by an earlier one is already in the generator, so adding
+    // it again has to make it the page that renders.
+    #[test]
+    fn readded_nested_type_becomes_the_page() {
+        let mut generator = create_generator();
+        generator.add::<AnotherConfig>();
+
+        let output = generate(generator, ApiDocsOptions::default());
+
+        assert!(output.starts_with("---\ntitle: AnotherConfig\n---"));
+        assert_snapshot!(output);
+    }
+
+    #[test]
+    fn without_required_or_aliases() {
+        let mut generator = SchemaGenerator::default();
+        generator.add::<DocsConfig>();
+
+        assert_snapshot!(generate(
+            generator,
+            ApiDocsOptions {
+                exclude_aliases: true,
+                mark_struct_fields_required: false,
+                ..ApiDocsOptions::default()
+            }
+        ));
+    }
+
+    #[test]
+    fn custom_link_extension() {
+        let mut generator = SchemaGenerator::default();
+        generator.add::<DocsConfig>();
+
+        let output = generate(
+            generator,
+            ApiDocsOptions {
+                link_extension: String::new(),
+                ..ApiDocsOptions::default()
+            },
+        );
+
+        assert!(output.contains("[`AnotherConfig`](./AnotherConfig)"));
+        assert!(output.contains("- [AnotherConfig](./AnotherConfig)"));
+        assert!(!output.contains(".md"));
+    }
+
+    #[test]
+    fn errors_without_schemas() {
+        let sandbox = create_empty_sandbox();
+        let file = sandbox.path().join("docs.md");
+
+        let error = SchemaGenerator::default()
+            .generate(&file, ApiDocsRenderer::default())
+            .unwrap_err();
+
+        assert!(error.to_string().contains("At least one type"));
     }
 }
 

--- a/crates/schematic/tests/generator_test.rs
+++ b/crates/schematic/tests/generator_test.rs
@@ -806,6 +806,25 @@ mod api_docs {
         assert!(output.contains("## Properties"));
     }
 
+    // A documentation tool that ids headings its own way needs the index
+    // links to follow it
+    #[test]
+    fn custom_anchors() {
+        let mut generator = SchemaGenerator::default();
+        generator.add::<DocsConfig>();
+
+        let output = generate(
+            generator,
+            ApiDocsOptions {
+                render_anchor: Box::new(|heading| format!("prop-{}", heading.replace('_', "-"))),
+                ..ApiDocsOptions::default()
+            },
+        );
+
+        assert!(output.contains("| [`nullable_items`](#prop-nullable-items) |"));
+        assert!(!output.contains("](#nullable_items)"));
+    }
+
     // The same function shapes inline links and the references list
     #[test]
     fn custom_links() {

--- a/crates/schematic/tests/generator_test.rs
+++ b/crates/schematic/tests/generator_test.rs
@@ -881,6 +881,75 @@ mod api_docs {
     }
 
     #[test]
+    fn generate_all_writes_every_page_and_an_index() {
+        let sandbox = create_empty_sandbox();
+        let dir = sandbox.path().join("docs");
+
+        ApiDocsRenderer::default()
+            .generate_all(&create_generator(), &dir)
+            .unwrap();
+
+        let mut files = fs::read_dir(&dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().into_string().unwrap())
+            .collect::<Vec<_>>();
+        files.sort();
+
+        assert_eq!(
+            files,
+            vec![
+                "AnotherConfig.md",
+                "BasicEnum.md",
+                "FallbackEnum.md",
+                "GenConfig.md",
+                "index.md",
+            ]
+        );
+
+        // A page is the same as the one a single generate renders
+        let single = generate(create_generator(), ApiDocsOptions::default());
+
+        assert_eq!(
+            fs::read_to_string(dir.join("GenConfig.md")).unwrap(),
+            single
+        );
+        assert!(
+            fs::read_to_string(dir.join("AnotherConfig.md"))
+                .unwrap()
+                .starts_with("---\ntitle: AnotherConfig\n---")
+        );
+
+        assert_snapshot!(fs::read_to_string(dir.join("index.md")).unwrap());
+    }
+
+    #[test]
+    fn generate_all_without_index_page() {
+        let sandbox = create_empty_sandbox();
+        let dir = sandbox.path().join("docs");
+
+        ApiDocsRenderer::new(ApiDocsOptions {
+            index_page: None,
+            ..ApiDocsOptions::default()
+        })
+        .generate_all(&create_generator(), &dir)
+        .unwrap();
+
+        assert!(!dir.join("index.md").exists());
+        assert!(dir.join("GenConfig.md").exists());
+    }
+
+    #[test]
+    fn generate_all_errors_without_schemas() {
+        let sandbox = create_empty_sandbox();
+
+        let error = ApiDocsRenderer::default()
+            .generate_all(&SchemaGenerator::default(), sandbox.path().join("docs"))
+            .unwrap_err();
+
+        assert!(error.to_string().contains("At least one type"));
+    }
+
+    #[test]
     fn errors_without_schemas() {
         let sandbox = create_empty_sandbox();
         let file = sandbox.path().join("docs.md");

--- a/crates/schematic/tests/generator_test.rs
+++ b/crates/schematic/tests/generator_test.rs
@@ -806,21 +806,28 @@ mod api_docs {
         assert!(output.contains("## Properties"));
     }
 
+    // The same function shapes inline links and the references list
     #[test]
-    fn custom_link_extension() {
+    fn custom_links() {
         let mut generator = SchemaGenerator::default();
         generator.add::<DocsConfig>();
 
         let output = generate(
             generator,
             ApiDocsOptions {
-                link_extension: String::new(),
+                render_link: Box::new(|name| {
+                    format!("<Link to=\"/docs/config/{name}\">{name}</Link>")
+                }),
                 ..ApiDocsOptions::default()
             },
         );
 
-        assert!(output.contains("[`AnotherConfig`](./AnotherConfig)"));
-        assert!(output.contains("- [AnotherConfig](./AnotherConfig)"));
+        assert!(
+            output.contains(
+                "| Type | <Link to=\"/docs/config/AnotherConfig\">AnotherConfig</Link> |"
+            )
+        );
+        assert!(output.contains("- <Link to=\"/docs/config/AnotherConfig\">AnotherConfig</Link>"));
         assert!(!output.contains(".md"));
     }
 

--- a/crates/schematic/tests/generator_test.rs
+++ b/crates/schematic/tests/generator_test.rs
@@ -683,6 +683,39 @@ mod api_docs {
     }
 
     #[test]
+    fn enum_table() {
+        let mut generator = SchemaGenerator::default();
+        generator.add::<FallbackEnum>();
+
+        assert_snapshot!(generate(
+            generator,
+            ApiDocsOptions {
+                enum_format: ApiDocsEnumFormat::Table,
+                ..ApiDocsOptions::default()
+            }
+        ));
+    }
+
+    // The table format only applies to unit enums, as union variants carry
+    // values that need a section to describe
+    #[test]
+    fn enum_table_leaves_unions_as_sections() {
+        let mut generator = SchemaGenerator::default();
+        generator.add::<Targets>();
+
+        let output = generate(
+            generator,
+            ApiDocsOptions {
+                enum_format: ApiDocsEnumFormat::Table,
+                ..ApiDocsOptions::default()
+            },
+        );
+
+        assert!(output.contains("## Index"));
+        assert!(output.contains("### `List`"));
+    }
+
+    #[test]
     fn union() {
         let mut generator = SchemaGenerator::default();
         generator.add::<Targets>();

--- a/crates/schematic/tests/generator_test.rs
+++ b/crates/schematic/tests/generator_test.rs
@@ -4,7 +4,7 @@ use indexmap::{IndexMap, IndexSet};
 use schematic::schema::{IntegerKind, IntegerType, SchemaGenerator, StringType, TemplateOptions};
 use schematic::*;
 use starbase_sandbox::{assert_snapshot, create_empty_sandbox};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::PathBuf;
 
@@ -716,6 +716,44 @@ mod api_docs {
                 ..ApiDocsOptions::default()
             }
         ));
+    }
+
+    #[test]
+    fn custom_frontmatter() {
+        let mut generator = SchemaGenerator::default();
+        generator.add::<AnotherConfig>();
+
+        let output = generate(
+            generator,
+            ApiDocsOptions {
+                frontmatter: BTreeMap::from_iter([
+                    ("sidebar_position".to_owned(), "2".to_owned()),
+                    ("description".to_owned(), "\"Another: config\"".to_owned()),
+                ]),
+                ..ApiDocsOptions::default()
+            },
+        );
+
+        assert!(output.starts_with(
+            "---\ntitle: AnotherConfig\ndescription: \"Another: config\"\nsidebar_position: 2\n---\n\nSome comment."
+        ));
+    }
+
+    #[test]
+    fn frontmatter_title_overrides_the_type_name() {
+        let mut generator = SchemaGenerator::default();
+        generator.add::<AnotherConfig>();
+
+        let output = generate(
+            generator,
+            ApiDocsOptions {
+                frontmatter: BTreeMap::from_iter([("title".to_owned(), "Another".to_owned())]),
+                ..ApiDocsOptions::default()
+            },
+        );
+
+        assert!(output.starts_with("---\ntitle: Another\n---\n"));
+        assert!(!output.contains("title: AnotherConfig"));
     }
 
     #[test]

--- a/crates/schematic/tests/generator_test.rs
+++ b/crates/schematic/tests/generator_test.rs
@@ -737,6 +737,55 @@ mod api_docs {
     }
 
     #[test]
+    fn custom_tags_and_description() {
+        let mut generator = SchemaGenerator::default();
+        generator.add::<DocsConfig>();
+
+        assert_snapshot!(generate(
+            generator,
+            ApiDocsOptions {
+                render_tags: Box::new(|tags| {
+                    tags.iter()
+                        .map(|tag| match tag {
+                            ApiDocsTag::Deprecated(Some(message)) => {
+                                format!("<Badge>{tag}</Badge> {message}")
+                            }
+                            _ => format!("<Badge>{tag}</Badge>"),
+                        })
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                }),
+                render_description: Box::new(|description| {
+                    format!(":::note\n{}\n:::", description.trim())
+                }),
+                ..ApiDocsOptions::default()
+            }
+        ));
+    }
+
+    // An empty result from either function omits that block, rather than
+    // leaving a blank line where it would have been
+    #[test]
+    fn empty_tags_and_description_are_omitted() {
+        let mut generator = SchemaGenerator::default();
+        generator.add::<AnotherConfig>();
+
+        let output = generate(
+            generator,
+            ApiDocsOptions {
+                render_tags: Box::new(|_| String::new()),
+                render_description: Box::new(|_| String::new()),
+                ..ApiDocsOptions::default()
+            },
+        );
+
+        assert!(!output.contains("Nullable"));
+        assert!(!output.contains("Some comment."));
+        assert!(!output.contains("\n\n\n"));
+        assert!(output.contains("### `enums`\n\n| Attribute | Value |"));
+    }
+
+    #[test]
     fn errors_without_schemas() {
         let sandbox = create_empty_sandbox();
         let file = sandbox.path().join("docs.md");

--- a/crates/schematic/tests/generator_test.rs
+++ b/crates/schematic/tests/generator_test.rs
@@ -719,6 +719,23 @@ mod api_docs {
     }
 
     #[test]
+    fn without_index() {
+        let mut generator = SchemaGenerator::default();
+        generator.add::<DocsConfig>();
+
+        let output = generate(
+            generator,
+            ApiDocsOptions {
+                include_index: false,
+                ..ApiDocsOptions::default()
+            },
+        );
+
+        assert!(!output.contains("## Index"));
+        assert!(output.contains("## Properties"));
+    }
+
+    #[test]
     fn custom_link_extension() {
         let mut generator = SchemaGenerator::default();
         generator.add::<DocsConfig>();

--- a/crates/schematic/tests/generator_test.rs
+++ b/crates/schematic/tests/generator_test.rs
@@ -828,6 +828,10 @@ mod api_docs {
             )
         );
         assert!(output.contains("- <Link to=\"/docs/config/AnotherConfig\">AnotherConfig</Link>"));
+        // A composite type stays one code span, and links its references beside it
+        assert!(output.contains(
+            "| Type | `AnotherConfig[]` |\n| References | <Link to=\"/docs/config/AnotherConfig\">AnotherConfig</Link> |"
+        ));
         assert!(!output.contains(".md"));
     }
 

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__all_field_shapes.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__all_field_shapes.snap
@@ -11,6 +11,24 @@ A config that exercises everything the docs can describe.
 - With a list item.
 - And another.
 
+## Index
+
+| Property | Type | Description |
+| --- | --- | --- |
+| [`boolean`](#boolean) | `boolean` | An optional boolean. |
+| [`duration`](#duration) | `{ nanos: number, secs: number }` | An inline struct. |
+| [`ident`](#ident) | `string` | A constrained string. |
+| [`level`](#level) | [`BasicEnum`](./BasicEnum.md) | An enum, which carries its own default. |
+| [`list`](#list) | [`AnotherConfig`](./AnotherConfig.md)`[]` | A list of nested configs. |
+| [`map`](#map) | `Record<string, `[`BasicEnum`](./BasicEnum.md)`>` | A map of enums. |
+| [`name`](#name) | `string` | A string with a default and aliases. |
+| [`nested`](#nested) | [`AnotherConfig`](./AnotherConfig.md) | An optional nested config. |
+| [`nullable_items`](#nullable_items) | `(`[`BasicEnum`](./BasicEnum.md)` \| null)[]` | A list of nullable enums. |
+| [`old_name`](#old_name) | `string` | A deprecated field, use `name` instead. |
+| [`pair`](#pair) | `[string, number]` | A tuple of values. |
+| [`port`](#port) | `number` | A constrained integer. |
+| [`targets`](#targets) | [`Targets`](./Targets.md) | A union of a list or a map. |
+
 ## Properties
 
 ### `boolean`

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__all_field_shapes.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__all_field_shapes.snap
@@ -1,0 +1,160 @@
+---
+source: crates/schematic/tests/generator_test.rs
+expression: "generate(generator, ApiDocsOptions::default())"
+---
+---
+title: DocsConfig
+---
+
+A config that exercises everything the docs can describe.
+
+- With a list item.
+- And another.
+
+## Properties
+
+### `boolean`
+
+> **Optional**
+
+An optional boolean.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `boolean` |
+
+### `duration`
+
+> **Required**
+
+An inline struct.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `{ nanos: number, secs: number }` |
+
+### `ident`
+
+> **Nullable**
+
+A constrained string.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Pattern | `^[a-z][a-z0-9-]*$` |
+| Min length | `1` |
+| Max length | `32` |
+
+### `level`
+
+> **Required**
+
+An enum, which carries its own default.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`BasicEnum`](./BasicEnum.md) |
+| Default | `"foo"` |
+| Values | `"foo"`, `"bar"`, `"baz"` |
+
+### `list`
+
+> **Required**
+
+A list of nested configs.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`AnotherConfig`](./AnotherConfig.md)`[]` |
+
+### `map`
+
+> **Required**
+
+A map of enums.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `Record<string, `[`BasicEnum`](./BasicEnum.md)`>` |
+
+### `name`
+
+> **Optional**
+
+A string with a default and aliases.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Default | `"hello"` |
+| Aliases | `label`, `title` |
+| Environment variable | `DOCS_NAME` |
+
+### `nested`
+
+> **Nullable**
+
+An optional nested config.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`AnotherConfig`](./AnotherConfig.md) |
+
+### `nullable_items`
+
+> **Required**
+
+A list of nullable enums.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `(`[`BasicEnum`](./BasicEnum.md)` \| null)[]` |
+
+### `old_name`
+
+> **Nullable** · **Deprecated** (Use `name` instead.)
+
+A deprecated field, use `name` instead.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+
+### `pair`
+
+> **Required**
+
+A tuple of values.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `[string, number]` |
+
+### `port`
+
+> **Required**
+
+A constrained integer.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `number` |
+| Minimum | `1024` |
+| Maximum | `49151` |
+
+### `targets`
+
+> **Required**
+
+A union of a list or a map.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`Targets`](./Targets.md) |
+
+## References
+
+- [AnotherConfig](./AnotherConfig.md)
+- [BasicEnum](./BasicEnum.md)
+- [Targets](./Targets.md)

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__all_field_shapes.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__all_field_shapes.snap
@@ -19,11 +19,11 @@ A config that exercises everything the docs can describe.
 | [`duration`](#duration) | `{ nanos: number, secs: number }` | An inline struct. |
 | [`ident`](#ident) | `string` | A constrained string. |
 | [`level`](#level) | [`BasicEnum`](./BasicEnum.md) | An enum, which carries its own default. |
-| [`list`](#list) | [`AnotherConfig`](./AnotherConfig.md)`[]` | A list of nested configs. |
-| [`map`](#map) | `Record<string, `[`BasicEnum`](./BasicEnum.md)`>` | A map of enums. |
+| [`list`](#list) | `AnotherConfig[]` | A list of nested configs. |
+| [`map`](#map) | `Record<string, BasicEnum>` | A map of enums. |
 | [`name`](#name) | `string` | A string with a default and aliases. |
 | [`nested`](#nested) | [`AnotherConfig`](./AnotherConfig.md) | An optional nested config. |
-| [`nullable_items`](#nullable_items) | `(`[`BasicEnum`](./BasicEnum.md)` \| null)[]` | A list of nullable enums. |
+| [`nullable_items`](#nullable_items) | `(BasicEnum \| null)[]` | A list of nullable enums. |
 | [`old_name`](#old_name) | `string` | A deprecated field, use `name` instead. |
 | [`pair`](#pair) | `[string, number]` | A tuple of values. |
 | [`port`](#port) | `number` | A constrained integer. |
@@ -84,7 +84,8 @@ A list of nested configs.
 
 | Attribute | Value |
 | --- | --- |
-| Type | [`AnotherConfig`](./AnotherConfig.md)`[]` |
+| Type | `AnotherConfig[]` |
+| References | [`AnotherConfig`](./AnotherConfig.md) |
 
 ### `map`
 
@@ -94,7 +95,8 @@ A map of enums.
 
 | Attribute | Value |
 | --- | --- |
-| Type | `Record<string, `[`BasicEnum`](./BasicEnum.md)`>` |
+| Type | `Record<string, BasicEnum>` |
+| References | [`BasicEnum`](./BasicEnum.md) |
 
 ### `name`
 
@@ -127,7 +129,8 @@ A list of nullable enums.
 
 | Attribute | Value |
 | --- | --- |
-| Type | `(`[`BasicEnum`](./BasicEnum.md)` \| null)[]` |
+| Type | `(BasicEnum \| null)[]` |
+| References | [`BasicEnum`](./BasicEnum.md) |
 
 ### `old_name`
 

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__all_field_shapes.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__all_field_shapes.snap
@@ -173,6 +173,6 @@ A union of a list or a map.
 
 ## References
 
-- [AnotherConfig](./AnotherConfig.md)
-- [BasicEnum](./BasicEnum.md)
-- [Targets](./Targets.md)
+- [`AnotherConfig`](./AnotherConfig.md)
+- [`BasicEnum`](./BasicEnum.md)
+- [`Targets`](./Targets.md)

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__custom_tags_and_description.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__custom_tags_and_description.snap
@@ -201,6 +201,6 @@ A union of a list or a map.
 
 ## References
 
-- [AnotherConfig](./AnotherConfig.md)
-- [BasicEnum](./BasicEnum.md)
-- [Targets](./Targets.md)
+- [`AnotherConfig`](./AnotherConfig.md)
+- [`BasicEnum`](./BasicEnum.md)
+- [`Targets`](./Targets.md)

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__custom_tags_and_description.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__custom_tags_and_description.snap
@@ -21,11 +21,11 @@ A config that exercises everything the docs can describe.
 | [`duration`](#duration) | `{ nanos: number, secs: number }` | An inline struct. |
 | [`ident`](#ident) | `string` | A constrained string. |
 | [`level`](#level) | [`BasicEnum`](./BasicEnum.md) | An enum, which carries its own default. |
-| [`list`](#list) | [`AnotherConfig`](./AnotherConfig.md)`[]` | A list of nested configs. |
-| [`map`](#map) | `Record<string, `[`BasicEnum`](./BasicEnum.md)`>` | A map of enums. |
+| [`list`](#list) | `AnotherConfig[]` | A list of nested configs. |
+| [`map`](#map) | `Record<string, BasicEnum>` | A map of enums. |
 | [`name`](#name) | `string` | A string with a default and aliases. |
 | [`nested`](#nested) | [`AnotherConfig`](./AnotherConfig.md) | An optional nested config. |
-| [`nullable_items`](#nullable_items) | `(`[`BasicEnum`](./BasicEnum.md)` \| null)[]` | A list of nullable enums. |
+| [`nullable_items`](#nullable_items) | `(BasicEnum \| null)[]` | A list of nullable enums. |
 | [`old_name`](#old_name) | `string` | A deprecated field, use `name` instead. |
 | [`pair`](#pair) | `[string, number]` | A tuple of values. |
 | [`port`](#port) | `number` | A constrained integer. |
@@ -96,7 +96,8 @@ A list of nested configs.
 
 | Attribute | Value |
 | --- | --- |
-| Type | [`AnotherConfig`](./AnotherConfig.md)`[]` |
+| Type | `AnotherConfig[]` |
+| References | [`AnotherConfig`](./AnotherConfig.md) |
 
 ### `map`
 
@@ -108,7 +109,8 @@ A map of enums.
 
 | Attribute | Value |
 | --- | --- |
-| Type | `Record<string, `[`BasicEnum`](./BasicEnum.md)`>` |
+| Type | `Record<string, BasicEnum>` |
+| References | [`BasicEnum`](./BasicEnum.md) |
 
 ### `name`
 
@@ -147,7 +149,8 @@ A list of nullable enums.
 
 | Attribute | Value |
 | --- | --- |
-| Type | `(`[`BasicEnum`](./BasicEnum.md)` \| null)[]` |
+| Type | `(BasicEnum \| null)[]` |
+| References | [`BasicEnum`](./BasicEnum.md) |
 
 ### `old_name`
 

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__custom_tags_and_description.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__custom_tags_and_description.snap
@@ -1,0 +1,188 @@
+---
+source: crates/schematic/tests/generator_test.rs
+expression: "generate(generator, ApiDocsOptions\n{\n    render_tags:\n    Box::new(|tags|\n    {\n        tags.iter().map(|tag| match tag\n        {\n            ApiDocsTag::Deprecated(Some(message)) =>\n            { format!(\"<Badge>{tag}</Badge> {message}\") } _ =>\n            format!(\"<Badge>{tag}</Badge>\"),\n        }).collect::<Vec<_>>().join(\" \")\n    }), render_description:\n    Box::new(|description|\n    { format!(\":::note\\n{}\\n:::\", description.trim()) }),\n    ..ApiDocsOptions::default()\n})"
+---
+---
+title: DocsConfig
+---
+
+:::note
+A config that exercises everything the docs can describe.
+
+- With a list item.
+- And another.
+:::
+
+## Properties
+
+### `boolean`
+
+<Badge>Optional</Badge>
+
+:::note
+An optional boolean.
+:::
+
+| Attribute | Value |
+| --- | --- |
+| Type | `boolean` |
+
+### `duration`
+
+<Badge>Required</Badge>
+
+:::note
+An inline struct.
+:::
+
+| Attribute | Value |
+| --- | --- |
+| Type | `{ nanos: number, secs: number }` |
+
+### `ident`
+
+<Badge>Nullable</Badge>
+
+:::note
+A constrained string.
+:::
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Pattern | `^[a-z][a-z0-9-]*$` |
+| Min length | `1` |
+| Max length | `32` |
+
+### `level`
+
+<Badge>Required</Badge>
+
+:::note
+An enum, which carries its own default.
+:::
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`BasicEnum`](./BasicEnum.md) |
+| Default | `"foo"` |
+| Values | `"foo"`, `"bar"`, `"baz"` |
+
+### `list`
+
+<Badge>Required</Badge>
+
+:::note
+A list of nested configs.
+:::
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`AnotherConfig`](./AnotherConfig.md)`[]` |
+
+### `map`
+
+<Badge>Required</Badge>
+
+:::note
+A map of enums.
+:::
+
+| Attribute | Value |
+| --- | --- |
+| Type | `Record<string, `[`BasicEnum`](./BasicEnum.md)`>` |
+
+### `name`
+
+<Badge>Optional</Badge>
+
+:::note
+A string with a default and aliases.
+:::
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Default | `"hello"` |
+| Aliases | `label`, `title` |
+| Environment variable | `DOCS_NAME` |
+
+### `nested`
+
+<Badge>Nullable</Badge>
+
+:::note
+An optional nested config.
+:::
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`AnotherConfig`](./AnotherConfig.md) |
+
+### `nullable_items`
+
+<Badge>Required</Badge>
+
+:::note
+A list of nullable enums.
+:::
+
+| Attribute | Value |
+| --- | --- |
+| Type | `(`[`BasicEnum`](./BasicEnum.md)` \| null)[]` |
+
+### `old_name`
+
+<Badge>Nullable</Badge> <Badge>Deprecated</Badge> Use `name` instead.
+
+:::note
+A deprecated field, use `name` instead.
+:::
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+
+### `pair`
+
+<Badge>Required</Badge>
+
+:::note
+A tuple of values.
+:::
+
+| Attribute | Value |
+| --- | --- |
+| Type | `[string, number]` |
+
+### `port`
+
+<Badge>Required</Badge>
+
+:::note
+A constrained integer.
+:::
+
+| Attribute | Value |
+| --- | --- |
+| Type | `number` |
+| Minimum | `1024` |
+| Maximum | `49151` |
+
+### `targets`
+
+<Badge>Required</Badge>
+
+:::note
+A union of a list or a map.
+:::
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`Targets`](./Targets.md) |
+
+## References
+
+- [AnotherConfig](./AnotherConfig.md)
+- [BasicEnum](./BasicEnum.md)
+- [Targets](./Targets.md)

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__custom_tags_and_description.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__custom_tags_and_description.snap
@@ -13,6 +13,24 @@ A config that exercises everything the docs can describe.
 - And another.
 :::
 
+## Index
+
+| Property | Type | Description |
+| --- | --- | --- |
+| [`boolean`](#boolean) | `boolean` | An optional boolean. |
+| [`duration`](#duration) | `{ nanos: number, secs: number }` | An inline struct. |
+| [`ident`](#ident) | `string` | A constrained string. |
+| [`level`](#level) | [`BasicEnum`](./BasicEnum.md) | An enum, which carries its own default. |
+| [`list`](#list) | [`AnotherConfig`](./AnotherConfig.md)`[]` | A list of nested configs. |
+| [`map`](#map) | `Record<string, `[`BasicEnum`](./BasicEnum.md)`>` | A map of enums. |
+| [`name`](#name) | `string` | A string with a default and aliases. |
+| [`nested`](#nested) | [`AnotherConfig`](./AnotherConfig.md) | An optional nested config. |
+| [`nullable_items`](#nullable_items) | `(`[`BasicEnum`](./BasicEnum.md)` \| null)[]` | A list of nullable enums. |
+| [`old_name`](#old_name) | `string` | A deprecated field, use `name` instead. |
+| [`pair`](#pair) | `[string, number]` | A tuple of values. |
+| [`port`](#port) | `number` | A constrained integer. |
+| [`targets`](#targets) | [`Targets`](./Targets.md) | A union of a list or a map. |
+
 ## Properties
 
 ### `boolean`

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__defaults.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__defaults.snap
@@ -290,6 +290,6 @@ This is a list of strings.
 
 ## References
 
-- [AnotherConfig](./AnotherConfig.md)
-- [BasicEnum](./BasicEnum.md)
-- [FallbackEnum](./FallbackEnum.md)
+- [`AnotherConfig`](./AnotherConfig.md)
+- [`BasicEnum`](./BasicEnum.md)
+- [`FallbackEnum`](./FallbackEnum.md)

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__defaults.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__defaults.snap
@@ -1,0 +1,262 @@
+---
+source: crates/schematic/tests/generator_test.rs
+expression: "generate(create_generator(), ApiDocsOptions::default())"
+---
+---
+title: GenConfig
+---
+
+> **Deprecated**
+
+## Properties
+
+### `boolean`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `boolean` |
+
+### `date`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `date` |
+
+### `datetime`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `date-time` |
+
+### `decimal`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `decimal` |
+
+### `enums`
+
+> **Required**
+
+This is a list of `enumerable` values.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`BasicEnum`](./BasicEnum.md) |
+| Default | `"foo"` |
+| Values | `"foo"`, `"bar"`, `"baz"` |
+
+### `fallback_enum`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`FallbackEnum`](./FallbackEnum.md) |
+| Default | `"foo"` |
+| Values | `"foo"`, `"bar"`, `"baz"` |
+
+### `flattened`
+
+> **Flattened**
+
+Flattened field...
+
+| Attribute | Value |
+| --- | --- |
+| Type | `Record<string, unknown>` |
+
+### `float32`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `number` |
+
+### `float64`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `number` |
+
+### `indexmap`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `Record<string, string>` |
+
+### `indexset`
+
+> **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string[]` |
+
+### `json_value`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `unknown` |
+
+### `map`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `Record<string, number>` |
+
+### `nested`
+
+> **Required**
+
+**Nested** field.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`AnotherConfig`](./AnotherConfig.md) |
+
+### `number`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `number` |
+
+### `path`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `path` |
+
+### `regex`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `regex` |
+
+### `rel_path`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `path` |
+
+### `string`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+
+### `time`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `time` |
+
+### `toml_value`
+
+> **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `unknown` |
+
+### `url`
+
+> **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `uri` |
+
+### `uuid`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `uuid` |
+
+### `vector`
+
+> **Required**
+
+This is a list of strings.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string[]` |
+
+### `version`
+
+> **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+
+### `version2`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+
+### `version_req`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+
+### `yaml_value`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `unknown` |
+
+## References
+
+- [AnotherConfig](./AnotherConfig.md)
+- [BasicEnum](./BasicEnum.md)
+- [FallbackEnum](./FallbackEnum.md)

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__defaults.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__defaults.snap
@@ -8,6 +8,39 @@ title: GenConfig
 
 > **Deprecated**
 
+## Index
+
+| Property | Type | Description |
+| --- | --- | --- |
+| [`boolean`](#boolean) | `boolean` |  |
+| [`date`](#date) | `string` |  |
+| [`datetime`](#datetime) | `string` |  |
+| [`decimal`](#decimal) | `string` |  |
+| [`enums`](#enums) | [`BasicEnum`](./BasicEnum.md) | This is a list of `enumerable` values. |
+| [`fallback_enum`](#fallback_enum) | [`FallbackEnum`](./FallbackEnum.md) |  |
+| [`flattened`](#flattened) | `Record<string, unknown>` | Flattened field... |
+| [`float32`](#float32) | `number` |  |
+| [`float64`](#float64) | `number` |  |
+| [`indexmap`](#indexmap) | `Record<string, string>` |  |
+| [`indexset`](#indexset) | `string[]` |  |
+| [`json_value`](#json_value) | `unknown` |  |
+| [`map`](#map) | `Record<string, number>` |  |
+| [`nested`](#nested) | [`AnotherConfig`](./AnotherConfig.md) | **Nested** field. |
+| [`number`](#number) | `number` |  |
+| [`path`](#path) | `string` |  |
+| [`regex`](#regex) | `string` |  |
+| [`rel_path`](#rel_path) | `string` |  |
+| [`string`](#string) | `string` |  |
+| [`time`](#time) | `string` |  |
+| [`toml_value`](#toml_value) | `unknown` |  |
+| [`url`](#url) | `string` |  |
+| [`uuid`](#uuid) | `string` |  |
+| [`vector`](#vector) | `string[]` | This is a list of strings. |
+| [`version`](#version) | `string` |  |
+| [`version2`](#version2) | `string` |  |
+| [`version_req`](#version_req) | `string` |  |
+| [`yaml_value`](#yaml_value) | `unknown` |  |
+
 ## Properties
 
 ### `boolean`

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__enum_table.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__enum_table.snap
@@ -1,0 +1,16 @@
+---
+source: crates/schematic/tests/generator_test.rs
+expression: "generate(generator, ApiDocsOptions\n{ enum_format: ApiDocsEnumFormat::Table, ..ApiDocsOptions::default() })"
+---
+---
+title: FallbackEnum
+---
+
+## Variants
+
+| Variant | Value | Tags | Description |
+| --- | --- | --- | --- |
+| `foo` | `"foo"` | **Default** |  |
+| `bar` | `"bar"` |  |  |
+| `baz` | `"baz"` |  |  |
+| `other` | `string` |  |  |

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__fallback_enum.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__fallback_enum.snap
@@ -1,0 +1,35 @@
+---
+source: crates/schematic/tests/generator_test.rs
+expression: "generate(generator, ApiDocsOptions::default())"
+---
+---
+title: FallbackEnum
+---
+
+## Variants
+
+### `foo`
+
+> **Default**
+
+| Attribute | Value |
+| --- | --- |
+| Value | `"foo"` |
+
+### `bar`
+
+| Attribute | Value |
+| --- | --- |
+| Value | `"bar"` |
+
+### `baz`
+
+| Attribute | Value |
+| --- | --- |
+| Value | `"baz"` |
+
+### `other`
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__fallback_enum.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__fallback_enum.snap
@@ -6,6 +6,15 @@ expression: "generate(generator, ApiDocsOptions::default())"
 title: FallbackEnum
 ---
 
+## Index
+
+| Variant | Type | Description |
+| --- | --- | --- |
+| [`foo`](#foo) | `"foo"` |  |
+| [`bar`](#bar) | `"bar"` |  |
+| [`baz`](#baz) | `"baz"` |  |
+| [`other`](#other) | `string` |  |
+
 ## Variants
 
 ### `foo`

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__generate_all_writes_every_page_and_an_index.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__generate_all_writes_every_page_and_an_index.snap
@@ -1,0 +1,16 @@
+---
+source: crates/schematic/tests/generator_test.rs
+expression: "fs::read_to_string(dir.join(\"index.md\")).unwrap()"
+---
+---
+title: Index
+---
+
+## Types
+
+| Type | Kind | Description |
+| --- | --- | --- |
+| [`AnotherConfig`](./AnotherConfig.md) | Struct | Some comment. |
+| [`BasicEnum`](./BasicEnum.md) | Enum | Docblock comment. |
+| [`FallbackEnum`](./FallbackEnum.md) | Enum |  |
+| [`GenConfig`](./GenConfig.md) | Struct |  |

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__partials.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__partials.snap
@@ -8,6 +8,39 @@ title: PartialGenConfig
 
 > **Deprecated**
 
+## Index
+
+| Property | Type | Description |
+| --- | --- | --- |
+| [`boolean`](#boolean) | `boolean` |  |
+| [`date`](#date) | `string` |  |
+| [`datetime`](#datetime) | `string` |  |
+| [`decimal`](#decimal) | `string` |  |
+| [`enums`](#enums) | [`BasicEnum`](./BasicEnum.md) | This is a list of `enumerable` values. |
+| [`fallback_enum`](#fallback_enum) | [`FallbackEnum`](./FallbackEnum.md) |  |
+| [`flattened`](#flattened) | `Record<string, unknown>` | Flattened field... |
+| [`float32`](#float32) | `number` |  |
+| [`float64`](#float64) | `number` |  |
+| [`indexmap`](#indexmap) | `Record<string, string>` |  |
+| [`indexset`](#indexset) | `string[]` |  |
+| [`json_value`](#json_value) | `unknown` |  |
+| [`map`](#map) | `Record<string, number>` |  |
+| [`nested`](#nested) | [`PartialAnotherConfig`](./PartialAnotherConfig.md) | **Nested** field. |
+| [`number`](#number) | `number` |  |
+| [`path`](#path) | `string` |  |
+| [`regex`](#regex) | `string` |  |
+| [`rel_path`](#rel_path) | `string` |  |
+| [`string`](#string) | `string` |  |
+| [`time`](#time) | `string` |  |
+| [`toml_value`](#toml_value) | `unknown` |  |
+| [`url`](#url) | `string` |  |
+| [`uuid`](#uuid) | `string` |  |
+| [`vector`](#vector) | `string[]` | This is a list of strings. |
+| [`version`](#version) | `string` |  |
+| [`version2`](#version2) | `string` |  |
+| [`version_req`](#version_req) | `string` |  |
+| [`yaml_value`](#yaml_value) | `unknown` |  |
+
 ## Properties
 
 ### `boolean`

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__partials.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__partials.snap
@@ -1,0 +1,262 @@
+---
+source: crates/schematic/tests/generator_test.rs
+expression: "generate(generator, ApiDocsOptions::default())"
+---
+---
+title: PartialGenConfig
+---
+
+> **Deprecated**
+
+## Properties
+
+### `boolean`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `boolean` |
+
+### `date`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `date` |
+
+### `datetime`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `date-time` |
+
+### `decimal`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `decimal` |
+
+### `enums`
+
+> **Optional** · **Nullable**
+
+This is a list of `enumerable` values.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`BasicEnum`](./BasicEnum.md) |
+| Default | `"foo"` |
+| Values | `"foo"`, `"bar"`, `"baz"` |
+
+### `fallback_enum`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`FallbackEnum`](./FallbackEnum.md) |
+| Default | `"foo"` |
+| Values | `"foo"`, `"bar"`, `"baz"` |
+
+### `flattened`
+
+> **Optional** · **Nullable** · **Flattened**
+
+Flattened field...
+
+| Attribute | Value |
+| --- | --- |
+| Type | `Record<string, unknown>` |
+
+### `float32`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `number` |
+
+### `float64`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `number` |
+
+### `indexmap`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `Record<string, string>` |
+
+### `indexset`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string[]` |
+
+### `json_value`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `unknown` |
+
+### `map`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `Record<string, number>` |
+
+### `nested`
+
+> **Optional** · **Nullable**
+
+**Nested** field.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`PartialAnotherConfig`](./PartialAnotherConfig.md) |
+
+### `number`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `number` |
+
+### `path`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `path` |
+
+### `regex`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `regex` |
+
+### `rel_path`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `path` |
+
+### `string`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+
+### `time`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `time` |
+
+### `toml_value`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `unknown` |
+
+### `url`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `uri` |
+
+### `uuid`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Format | `uuid` |
+
+### `vector`
+
+> **Optional** · **Nullable**
+
+This is a list of strings.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string[]` |
+
+### `version`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+
+### `version2`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+
+### `version_req`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+
+### `yaml_value`
+
+> **Optional** · **Nullable**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `unknown` |
+
+## References
+
+- [BasicEnum](./BasicEnum.md)
+- [FallbackEnum](./FallbackEnum.md)
+- [PartialAnotherConfig](./PartialAnotherConfig.md)

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__partials.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__partials.snap
@@ -290,6 +290,6 @@ This is a list of strings.
 
 ## References
 
-- [BasicEnum](./BasicEnum.md)
-- [FallbackEnum](./FallbackEnum.md)
-- [PartialAnotherConfig](./PartialAnotherConfig.md)
+- [`BasicEnum`](./BasicEnum.md)
+- [`FallbackEnum`](./FallbackEnum.md)
+- [`PartialAnotherConfig`](./PartialAnotherConfig.md)

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__readded_nested_type_becomes_the_page.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__readded_nested_type_becomes_the_page.snap
@@ -8,6 +8,13 @@ title: AnotherConfig
 
 Some comment.
 
+## Index
+
+| Property | Type | Description |
+| --- | --- | --- |
+| [`enums`](#enums) | [`BasicEnum`](./BasicEnum.md) | An optional enum. |
+| [`opt`](#opt) | `string` | An optional string. |
+
 ## Properties
 
 ### `enums`

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__readded_nested_type_becomes_the_page.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__readded_nested_type_becomes_the_page.snap
@@ -41,4 +41,4 @@ An optional string.
 
 ## References
 
-- [BasicEnum](./BasicEnum.md)
+- [`BasicEnum`](./BasicEnum.md)

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__readded_nested_type_becomes_the_page.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__readded_nested_type_becomes_the_page.snap
@@ -1,0 +1,37 @@
+---
+source: crates/schematic/tests/generator_test.rs
+expression: output
+---
+---
+title: AnotherConfig
+---
+
+Some comment.
+
+## Properties
+
+### `enums`
+
+> **Nullable**
+
+An optional enum.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`BasicEnum`](./BasicEnum.md) |
+| Default | `"foo"` |
+| Values | `"foo"`, `"bar"`, `"baz"` |
+
+### `opt`
+
+> **Nullable**
+
+An optional string.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+
+## References
+
+- [BasicEnum](./BasicEnum.md)

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__template_config.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__template_config.snap
@@ -1,0 +1,192 @@
+---
+source: crates/schematic/tests/generator_test.rs
+expression: "generate(create_template_generator(), ApiDocsOptions::default())"
+---
+---
+title: TemplateConfig
+---
+
+## Properties
+
+### `boolean`
+
+> **Required**
+
+This is a boolean with a medium length description.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `boolean` |
+| Environment variable | `TEMPLATE_BOOLEAN` |
+
+### `empty_array`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `number[]` |
+
+### `empty_object`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `Record<string, number>` |
+
+### `enums`
+
+> **Required** · **Deprecated** (Dont use enums!)
+
+This is an enum with a medium length description and deprecated.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`BasicEnum`](./BasicEnum.md) |
+| Default | `"foo"` |
+| Values | `"foo"`, `"bar"`, `"baz"` |
+
+### `expand_array`
+
+> **Required**
+
+This field is testing array expansion.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`AnotherConfig`](./AnotherConfig.md)`[]` |
+
+### `expand_array_primitive`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `number[]` |
+
+### `expand_object`
+
+> **Required**
+
+This field is testing object expansion.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `Record<string, `[`AnotherConfig`](./AnotherConfig.md)`>` |
+
+### `expand_object_primitive`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `Record<string, number>` |
+
+### `fallback_enum`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`FallbackEnum`](./FallbackEnum.md) |
+| Default | `"foo"` |
+| Values | `"foo"`, `"bar"`, `"baz"` |
+
+### `float32`
+
+> **Required** · **Deprecated**
+
+This is a float thats deprecated.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `number` |
+
+### `float64`
+
+> **Optional**
+
+This is a float.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `number` |
+| Default | `1.23` |
+
+### `map`
+
+> **Required**
+
+This is a map of numbers.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `Record<string, number>` |
+
+### `nested`
+
+> **Required**
+
+This is a nested struct with its own fields.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`AnotherConfig`](./AnotherConfig.md) |
+
+### `number`
+
+> **Required**
+
+This is a number with a long description.
+This is a number with a long description.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `number` |
+
+### `one`
+
+> **Required**
+
+This is a nested struct with its own fields.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`OneDepthConfig`](./OneDepthConfig.md) |
+
+### `skipped`
+
+> **Required**
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+
+### `string`
+
+> **Optional**
+
+This is a string.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Default | `"abc"` |
+
+### `vector`
+
+> **Required**
+
+This is a list of strings.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string[]` |
+
+## References
+
+- [AnotherConfig](./AnotherConfig.md)
+- [BasicEnum](./BasicEnum.md)
+- [FallbackEnum](./FallbackEnum.md)
+- [OneDepthConfig](./OneDepthConfig.md)

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__template_config.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__template_config.snap
@@ -209,7 +209,7 @@ This is a list of strings.
 
 ## References
 
-- [AnotherConfig](./AnotherConfig.md)
-- [BasicEnum](./BasicEnum.md)
-- [FallbackEnum](./FallbackEnum.md)
-- [OneDepthConfig](./OneDepthConfig.md)
+- [`AnotherConfig`](./AnotherConfig.md)
+- [`BasicEnum`](./BasicEnum.md)
+- [`FallbackEnum`](./FallbackEnum.md)
+- [`OneDepthConfig`](./OneDepthConfig.md)

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__template_config.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__template_config.snap
@@ -6,6 +6,29 @@ expression: "generate(create_template_generator(), ApiDocsOptions::default())"
 title: TemplateConfig
 ---
 
+## Index
+
+| Property | Type | Description |
+| --- | --- | --- |
+| [`boolean`](#boolean) | `boolean` | This is a boolean with a medium length description. |
+| [`empty_array`](#empty_array) | `number[]` |  |
+| [`empty_object`](#empty_object) | `Record<string, number>` |  |
+| [`enums`](#enums) | [`BasicEnum`](./BasicEnum.md) | This is an enum with a medium length description and deprecated. |
+| [`expand_array`](#expand_array) | [`AnotherConfig`](./AnotherConfig.md)`[]` | This field is testing array expansion. |
+| [`expand_array_primitive`](#expand_array_primitive) | `number[]` |  |
+| [`expand_object`](#expand_object) | `Record<string, `[`AnotherConfig`](./AnotherConfig.md)`>` | This field is testing object expansion. |
+| [`expand_object_primitive`](#expand_object_primitive) | `Record<string, number>` |  |
+| [`fallback_enum`](#fallback_enum) | [`FallbackEnum`](./FallbackEnum.md) |  |
+| [`float32`](#float32) | `number` | This is a float thats deprecated. |
+| [`float64`](#float64) | `number` | This is a float. |
+| [`map`](#map) | `Record<string, number>` | This is a map of numbers. |
+| [`nested`](#nested) | [`AnotherConfig`](./AnotherConfig.md) | This is a nested struct with its own fields. |
+| [`number`](#number) | `number` | This is a number with a long description. This is a number with a long description. |
+| [`one`](#one) | [`OneDepthConfig`](./OneDepthConfig.md) | This is a nested struct with its own fields. |
+| [`skipped`](#skipped) | `string` |  |
+| [`string`](#string) | `string` | This is a string. |
+| [`vector`](#vector) | `string[]` | This is a list of strings. |
+
 ## Properties
 
 ### `boolean`

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__template_config.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__template_config.snap
@@ -14,9 +14,9 @@ title: TemplateConfig
 | [`empty_array`](#empty_array) | `number[]` |  |
 | [`empty_object`](#empty_object) | `Record<string, number>` |  |
 | [`enums`](#enums) | [`BasicEnum`](./BasicEnum.md) | This is an enum with a medium length description and deprecated. |
-| [`expand_array`](#expand_array) | [`AnotherConfig`](./AnotherConfig.md)`[]` | This field is testing array expansion. |
+| [`expand_array`](#expand_array) | `AnotherConfig[]` | This field is testing array expansion. |
 | [`expand_array_primitive`](#expand_array_primitive) | `number[]` |  |
-| [`expand_object`](#expand_object) | `Record<string, `[`AnotherConfig`](./AnotherConfig.md)`>` | This field is testing object expansion. |
+| [`expand_object`](#expand_object) | `Record<string, AnotherConfig>` | This field is testing object expansion. |
 | [`expand_object_primitive`](#expand_object_primitive) | `Record<string, number>` |  |
 | [`fallback_enum`](#fallback_enum) | [`FallbackEnum`](./FallbackEnum.md) |  |
 | [`float32`](#float32) | `number` | This is a float thats deprecated. |
@@ -78,7 +78,8 @@ This field is testing array expansion.
 
 | Attribute | Value |
 | --- | --- |
-| Type | [`AnotherConfig`](./AnotherConfig.md)`[]` |
+| Type | `AnotherConfig[]` |
+| References | [`AnotherConfig`](./AnotherConfig.md) |
 
 ### `expand_array_primitive`
 
@@ -96,7 +97,8 @@ This field is testing object expansion.
 
 | Attribute | Value |
 | --- | --- |
-| Type | `Record<string, `[`AnotherConfig`](./AnotherConfig.md)`>` |
+| Type | `Record<string, AnotherConfig>` |
+| References | [`AnotherConfig`](./AnotherConfig.md) |
 
 ### `expand_object_primitive`
 

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__union.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__union.snap
@@ -10,7 +10,7 @@ Either a list of targets, or a map of targets to paths.
 
 ## Variants
 
-### `string[]`
+### `List`
 
 A list of targets.
 
@@ -18,7 +18,7 @@ A list of targets.
 | --- | --- |
 | Type | `string[]` |
 
-### `Record<string, string>`
+### `Map`
 
 A map of targets.
 

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__union.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__union.snap
@@ -1,0 +1,27 @@
+---
+source: crates/schematic/tests/generator_test.rs
+expression: "generate(generator, ApiDocsOptions::default())"
+---
+---
+title: Targets
+---
+
+Either a list of targets, or a map of targets to paths.
+
+## Variants
+
+### `string[]`
+
+A list of targets.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string[]` |
+
+### `Record<string, string>`
+
+A map of targets.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `Record<string, string>` |

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__union.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__union.snap
@@ -8,6 +8,13 @@ title: Targets
 
 Either a list of targets, or a map of targets to paths.
 
+## Index
+
+| Variant | Type | Description |
+| --- | --- | --- |
+| [`List`](#list) | `string[]` | A list of targets. |
+| [`Map`](#map) | `Record<string, string>` | A map of targets. |
+
 ## Variants
 
 ### `List`

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__unit_enum.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__unit_enum.snap
@@ -8,6 +8,14 @@ title: BasicEnum
 
 Docblock comment.
 
+## Index
+
+| Variant | Type | Description |
+| --- | --- | --- |
+| [`foo`](#foo) | `"foo"` |  |
+| [`bar`](#bar) | `"bar"` |  |
+| [`baz`](#baz) | `"baz"` |  |
+
 ## Variants
 
 ### `foo`

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__unit_enum.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__unit_enum.snap
@@ -1,0 +1,31 @@
+---
+source: crates/schematic/tests/generator_test.rs
+expression: "generate(generator, ApiDocsOptions::default())"
+---
+---
+title: BasicEnum
+---
+
+Docblock comment.
+
+## Variants
+
+### `foo`
+
+> **Default**
+
+| Attribute | Value |
+| --- | --- |
+| Value | `"foo"` |
+
+### `bar`
+
+| Attribute | Value |
+| --- | --- |
+| Value | `"bar"` |
+
+### `baz`
+
+| Attribute | Value |
+| --- | --- |
+| Value | `"baz"` |

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__without_required_or_aliases.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__without_required_or_aliases.snap
@@ -11,6 +11,24 @@ A config that exercises everything the docs can describe.
 - With a list item.
 - And another.
 
+## Index
+
+| Property | Type | Description |
+| --- | --- | --- |
+| [`boolean`](#boolean) | `boolean` | An optional boolean. |
+| [`duration`](#duration) | `{ nanos: number, secs: number }` | An inline struct. |
+| [`ident`](#ident) | `string` | A constrained string. |
+| [`level`](#level) | [`BasicEnum`](./BasicEnum.md) | An enum, which carries its own default. |
+| [`list`](#list) | [`AnotherConfig`](./AnotherConfig.md)`[]` | A list of nested configs. |
+| [`map`](#map) | `Record<string, `[`BasicEnum`](./BasicEnum.md)`>` | A map of enums. |
+| [`name`](#name) | `string` | A string with a default and aliases. |
+| [`nested`](#nested) | [`AnotherConfig`](./AnotherConfig.md) | An optional nested config. |
+| [`nullable_items`](#nullable_items) | `(`[`BasicEnum`](./BasicEnum.md)` \| null)[]` | A list of nullable enums. |
+| [`old_name`](#old_name) | `string` | A deprecated field, use `name` instead. |
+| [`pair`](#pair) | `[string, number]` | A tuple of values. |
+| [`port`](#port) | `number` | A constrained integer. |
+| [`targets`](#targets) | [`Targets`](./Targets.md) | A union of a list or a map. |
+
 ## Properties
 
 ### `boolean`

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__without_required_or_aliases.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__without_required_or_aliases.snap
@@ -1,0 +1,143 @@
+---
+source: crates/schematic/tests/generator_test.rs
+expression: "generate(generator, ApiDocsOptions\n{\n    exclude_aliases: true, mark_struct_fields_required: false,\n    ..ApiDocsOptions::default()\n})"
+---
+---
+title: DocsConfig
+---
+
+A config that exercises everything the docs can describe.
+
+- With a list item.
+- And another.
+
+## Properties
+
+### `boolean`
+
+> **Optional**
+
+An optional boolean.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `boolean` |
+
+### `duration`
+
+An inline struct.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `{ nanos: number, secs: number }` |
+
+### `ident`
+
+> **Nullable**
+
+A constrained string.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Pattern | `^[a-z][a-z0-9-]*$` |
+| Min length | `1` |
+| Max length | `32` |
+
+### `level`
+
+An enum, which carries its own default.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`BasicEnum`](./BasicEnum.md) |
+| Default | `"foo"` |
+| Values | `"foo"`, `"bar"`, `"baz"` |
+
+### `list`
+
+A list of nested configs.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`AnotherConfig`](./AnotherConfig.md)`[]` |
+
+### `map`
+
+A map of enums.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `Record<string, `[`BasicEnum`](./BasicEnum.md)`>` |
+
+### `name`
+
+> **Optional**
+
+A string with a default and aliases.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+| Default | `"hello"` |
+| Environment variable | `DOCS_NAME` |
+
+### `nested`
+
+> **Nullable**
+
+An optional nested config.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`AnotherConfig`](./AnotherConfig.md) |
+
+### `nullable_items`
+
+A list of nullable enums.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `(`[`BasicEnum`](./BasicEnum.md)` \| null)[]` |
+
+### `old_name`
+
+> **Nullable** · **Deprecated** (Use `name` instead.)
+
+A deprecated field, use `name` instead.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `string` |
+
+### `pair`
+
+A tuple of values.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `[string, number]` |
+
+### `port`
+
+A constrained integer.
+
+| Attribute | Value |
+| --- | --- |
+| Type | `number` |
+| Minimum | `1024` |
+| Maximum | `49151` |
+
+### `targets`
+
+A union of a list or a map.
+
+| Attribute | Value |
+| --- | --- |
+| Type | [`Targets`](./Targets.md) |
+
+## References
+
+- [AnotherConfig](./AnotherConfig.md)
+- [BasicEnum](./BasicEnum.md)
+- [Targets](./Targets.md)

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__without_required_or_aliases.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__without_required_or_aliases.snap
@@ -156,6 +156,6 @@ A union of a list or a map.
 
 ## References
 
-- [AnotherConfig](./AnotherConfig.md)
-- [BasicEnum](./BasicEnum.md)
-- [Targets](./Targets.md)
+- [`AnotherConfig`](./AnotherConfig.md)
+- [`BasicEnum`](./BasicEnum.md)
+- [`Targets`](./Targets.md)

--- a/crates/schematic/tests/snapshots/generator_test__api_docs__without_required_or_aliases.snap
+++ b/crates/schematic/tests/snapshots/generator_test__api_docs__without_required_or_aliases.snap
@@ -19,11 +19,11 @@ A config that exercises everything the docs can describe.
 | [`duration`](#duration) | `{ nanos: number, secs: number }` | An inline struct. |
 | [`ident`](#ident) | `string` | A constrained string. |
 | [`level`](#level) | [`BasicEnum`](./BasicEnum.md) | An enum, which carries its own default. |
-| [`list`](#list) | [`AnotherConfig`](./AnotherConfig.md)`[]` | A list of nested configs. |
-| [`map`](#map) | `Record<string, `[`BasicEnum`](./BasicEnum.md)`>` | A map of enums. |
+| [`list`](#list) | `AnotherConfig[]` | A list of nested configs. |
+| [`map`](#map) | `Record<string, BasicEnum>` | A map of enums. |
 | [`name`](#name) | `string` | A string with a default and aliases. |
 | [`nested`](#nested) | [`AnotherConfig`](./AnotherConfig.md) | An optional nested config. |
-| [`nullable_items`](#nullable_items) | `(`[`BasicEnum`](./BasicEnum.md)` \| null)[]` | A list of nullable enums. |
+| [`nullable_items`](#nullable_items) | `(BasicEnum \| null)[]` | A list of nullable enums. |
 | [`old_name`](#old_name) | `string` | A deprecated field, use `name` instead. |
 | [`pair`](#pair) | `[string, number]` | A tuple of values. |
 | [`port`](#port) | `number` | A constrained integer. |
@@ -78,7 +78,8 @@ A list of nested configs.
 
 | Attribute | Value |
 | --- | --- |
-| Type | [`AnotherConfig`](./AnotherConfig.md)`[]` |
+| Type | `AnotherConfig[]` |
+| References | [`AnotherConfig`](./AnotherConfig.md) |
 
 ### `map`
 
@@ -86,7 +87,8 @@ A map of enums.
 
 | Attribute | Value |
 | --- | --- |
-| Type | `Record<string, `[`BasicEnum`](./BasicEnum.md)`>` |
+| Type | `Record<string, BasicEnum>` |
+| References | [`BasicEnum`](./BasicEnum.md) |
 
 ### `name`
 
@@ -116,7 +118,8 @@ A list of nullable enums.
 
 | Attribute | Value |
 | --- | --- |
-| Type | `(`[`BasicEnum`](./BasicEnum.md)` \| null)[]` |
+| Type | `(BasicEnum \| null)[]` |
+| References | [`BasicEnum`](./BasicEnum.md) |
 
 ### `old_name`
 

--- a/crates/schematic/tests/snapshots/macros_test__generates_typescript-2.snap
+++ b/crates/schematic/tests/snapshots/macros_test__generates_typescript-2.snap
@@ -50,11 +50,6 @@ export type ValueTypesBase = {
 
 export type ValueTypes = ValueTypesBase & ValueTypesRest;
 
-export type OptionalValues = {
-	optional: string | null,
-	required: boolean,
-};
-
 export type DefaultValues = {
 	array?: number[],
 	array_opt: number[] | null,
@@ -170,6 +165,11 @@ export type Comments = {
 };
 
 export type UnnamedMultiple = [string, number | null, boolean];
+
+export type OptionalValues = {
+	optional: string | null,
+	required: boolean,
+};
 
 export type PartialDefaultValues = {
 	array?: number[] | null,

--- a/crates/schematic/tests/snapshots/macros_test__generates_typescript.snap
+++ b/crates/schematic/tests/snapshots/macros_test__generates_typescript.snap
@@ -34,11 +34,6 @@ export interface ValueTypesBase {
 
 export type ValueTypes = ValueTypesBase & ValueTypesRest;
 
-export interface OptionalValues {
-	optional: string | null;
-	required: boolean;
-}
-
 export interface DefaultValues {
 	array?: number[];
 	array_opt: number[] | null;
@@ -154,6 +149,11 @@ export interface Comments {
 }
 
 export type UnnamedMultiple = [string, number | null, boolean];
+
+export interface OptionalValues {
+	optional: string | null;
+	required: boolean;
+}
 
 export interface PartialDefaultValues {
 	array?: number[] | null;

--- a/crates/schematic/tests/snapshots/partialize_test__compounds.snap
+++ b/crates/schematic/tests/snapshots/partialize_test__compounds.snap
@@ -49,6 +49,7 @@ expression: "create_diff::<Compounds>()"
 🟩                                default_index: None,
 🟩                                partial: false,
 🟩                                operator: AnyOf,
+🟩                                variants_names: None,
 🟩                                variants_types: [
 🟩                                    Schema {
 🟩                                        deprecated: None,
@@ -115,6 +116,7 @@ expression: "create_diff::<Compounds>()"
 ⬛️                                default_index: None,
 ⬛️                                partial: false,
 ⬛️                                operator: AnyOf,
+⬛️                                variants_names: None,
 ⬛️                                variants_types: [
 ⬛️                                    Schema {
 ⬛️                                        deprecated: None,
@@ -216,6 +218,7 @@ expression: "create_diff::<Compounds>()"
 🟩                                default_index: None,
 🟩                                partial: false,
 🟩                                operator: AnyOf,
+🟩                                variants_names: None,
 🟩                                variants_types: [
 🟩                                    Schema {
 🟩                                        deprecated: None,
@@ -292,6 +295,7 @@ expression: "create_diff::<Compounds>()"
 ⬛️                                default_index: None,
 ⬛️                                partial: false,
 ⬛️                                operator: AnyOf,
+⬛️                                variants_names: None,
 ⬛️                                variants_types: [
 ⬛️                                    Schema {
 ⬛️                                        deprecated: None,

--- a/crates/schematic/tests/snapshots/partialize_test__enum_adjacent.snap
+++ b/crates/schematic/tests/snapshots/partialize_test__enum_adjacent.snap
@@ -15,6 +15,14 @@ expression: "create_diff::<AdjacentTagged>()"
 ⬛️            default_index: None,
 ⬛️            partial: false,
 ⬛️            operator: AnyOf,
+⬛️            variants_names: Some(
+⬛️                [
+⬛️                    "Foo",
+⬛️                    "Bar",
+⬛️                    "Baz",
+⬛️                    "Qux",
+⬛️                ],
+⬛️            ),
 ⬛️            variants_types: [
 ⬛️                Schema {
 ⬛️                    deprecated: None,
@@ -256,6 +264,7 @@ expression: "create_diff::<AdjacentTagged>()"
 🟩                                                                    default_index: None,
 🟩                                                                    partial: false,
 🟩                                                                    operator: AnyOf,
+🟩                                                                    variants_names: None,
 🟩                                                                    variants_types: [
 🟩                                                                        Schema {
 🟩                                                                            deprecated: None,

--- a/crates/schematic/tests/snapshots/partialize_test__enum_external.snap
+++ b/crates/schematic/tests/snapshots/partialize_test__enum_external.snap
@@ -15,6 +15,14 @@ expression: "create_diff::<ExternalTagged>()"
 ⬛️            default_index: None,
 ⬛️            partial: false,
 ⬛️            operator: AnyOf,
+⬛️            variants_names: Some(
+⬛️                [
+⬛️                    "Foo",
+⬛️                    "Bar",
+⬛️                    "Baz",
+⬛️                    "Qux",
+⬛️                ],
+⬛️            ),
 ⬛️            variants_types: [
 ⬛️                Schema {
 ⬛️                    deprecated: None,
@@ -155,6 +163,7 @@ expression: "create_diff::<ExternalTagged>()"
 🟩                                                                    default_index: None,
 🟩                                                                    partial: false,
 🟩                                                                    operator: AnyOf,
+🟩                                                                    variants_names: None,
 🟩                                                                    variants_types: [
 🟩                                                                        Schema {
 🟩                                                                            deprecated: None,

--- a/crates/schematic/tests/snapshots/partialize_test__enum_internal.snap
+++ b/crates/schematic/tests/snapshots/partialize_test__enum_internal.snap
@@ -15,6 +15,14 @@ expression: "create_diff::<InternalTagged>()"
 ⬛️            default_index: None,
 ⬛️            partial: false,
 ⬛️            operator: AnyOf,
+⬛️            variants_names: Some(
+⬛️                [
+⬛️                    "Foo",
+⬛️                    "Bar",
+⬛️                    "Baz",
+⬛️                    "Qux",
+⬛️                ],
+⬛️            ),
 ⬛️            variants_types: [
 ⬛️                Schema {
 ⬛️                    deprecated: None,
@@ -118,6 +126,7 @@ expression: "create_diff::<InternalTagged>()"
 🟩                                                default_index: None,
 🟩                                                partial: false,
 🟩                                                operator: AnyOf,
+🟩                                                variants_names: None,
 🟩                                                variants_types: [
 🟩                                                    Schema {
 🟩                                                        deprecated: None,
@@ -176,6 +185,7 @@ expression: "create_diff::<InternalTagged>()"
 🟩                                                default_index: None,
 🟩                                                partial: false,
 🟩                                                operator: AnyOf,
+🟩                                                variants_names: None,
 🟩                                                variants_types: [
 🟩                                                    Schema {
 🟩                                                        deprecated: None,

--- a/crates/schematic/tests/snapshots/partialize_test__enum_untagged.snap
+++ b/crates/schematic/tests/snapshots/partialize_test__enum_untagged.snap
@@ -15,6 +15,14 @@ expression: "create_diff::<Untagged>()"
 ⬛️            default_index: None,
 ⬛️            partial: false,
 ⬛️            operator: AnyOf,
+⬛️            variants_names: Some(
+⬛️                [
+⬛️                    "Foo",
+⬛️                    "Bar",
+⬛️                    "Baz",
+⬛️                    "Qux",
+⬛️                ],
+⬛️            ),
 ⬛️            variants_types: [
 ⬛️                Schema {
 ⬛️                    deprecated: None,
@@ -114,6 +122,7 @@ expression: "create_diff::<Untagged>()"
 🟩                                                default_index: None,
 🟩                                                partial: false,
 🟩                                                operator: AnyOf,
+🟩                                                variants_names: None,
 🟩                                                variants_types: [
 🟩                                                    Schema {
 🟩                                                        deprecated: None,

--- a/crates/schematic/tests/snapshots/partialize_test__enums.snap
+++ b/crates/schematic/tests/snapshots/partialize_test__enums.snap
@@ -62,6 +62,7 @@ expression: "create_diff::<Enums>()"
 🟩                                default_index: None,
 🟩                                partial: false,
 🟩                                operator: AnyOf,
+🟩                                variants_names: None,
 🟩                                variants_types: [
 🟩                                    Schema {
 🟩                                        deprecated: None,
@@ -97,31 +98,6 @@ expression: "create_diff::<Enums>()"
 🟥                                                    LiteralType {
 🟥                                                        value: String(
 🟥                                                            "b",
-🟥                                                        ),
-🟥                                                    },
-🟥                                                ),
-🟥                                            },
-🟥                                            deprecated: None,
-🟥                                            env_var: None,
-🟥                                            flatten: false,
-🟥                                            hidden: false,
-🟥                                            nullable: false,
-🟥                                            optional: false,
-🟥                                            read_only: false,
-🟥                                            write_only: false,
-🟥                                        },
-🟥                                        "c": SchemaField {
-🟥                                            aliases: [],
-🟥                                            comment: None,
-🟥                                            schema: Schema {
-🟥                                                deprecated: None,
-🟥                                                description: None,
-🟥                                                name: None,
-🟥                                                nullable: false,
-🟥                                                ty: Literal(
-🟥                                                    LiteralType {
-🟥                                                        value: String(
-🟥                                                            "c",
 🟥                                                        ),
 🟩                                                values: [
 🟩                                                    String(
@@ -223,16 +199,41 @@ expression: "create_diff::<Enums>()"
 🟥                                            read_only: false,
 🟥                                            write_only: false,
 🟥                                        },
+🟥                                        "c": SchemaField {
+🟥                                            aliases: [],
+🟥                                            comment: None,
+🟥                                            schema: Schema {
+🟥                                                deprecated: None,
+🟥                                                description: None,
+🟥                                                name: None,
+🟥                                                nullable: false,
+🟥                                                ty: Literal(
+🟥                                                    LiteralType {
+🟥                                                        value: String(
+🟥                                                            "c",
+🟥                                                        ),
+🟥                                                    },
+🟥                                                ),
+🟥                                            },
+🟥                                            deprecated: None,
+🟥                                            env_var: None,
+🟥                                            flatten: false,
+🟥                                            hidden: false,
+🟥                                            nullable: false,
+🟥                                            optional: false,
+🟥                                            read_only: false,
+🟥                                            write_only: false,
+🟥                                        },
 🟩                                        ),
-⬛️                                    },
-🟥                                ),
+🟩                                    },
 🟩                                    Schema {
 🟩                                        deprecated: None,
 🟩                                        description: None,
 🟩                                        name: None,
 🟩                                        nullable: false,
 🟩                                        ty: Null,
-🟩                                    },
+⬛️                                    },
+🟥                                ),
 🟩                                ],
 ⬛️                            },
 ⬛️                        ),
@@ -261,6 +262,7 @@ expression: "create_diff::<Enums>()"
 ⬛️                                default_index: None,
 ⬛️                                partial: false,
 ⬛️                                operator: AnyOf,
+⬛️                                variants_names: None,
 ⬛️                                variants_types: [
 ⬛️                                    Schema {
 ⬛️                                        deprecated: None,
@@ -437,6 +439,7 @@ expression: "create_diff::<Enums>()"
 🟩                                default_index: None,
 🟩                                partial: false,
 🟩                                operator: AnyOf,
+🟩                                variants_names: None,
 🟩                                variants_types: [
 🟩                                    Schema {
 🟩                                        deprecated: None,
@@ -655,15 +658,15 @@ expression: "create_diff::<Enums>()"
 🟥                                            write_only: false,
 🟥                                        },
 🟩                                        ),
-🟩                                    },
+⬛️                                    },
+🟥                                ),
 🟩                                    Schema {
 🟩                                        deprecated: None,
 🟩                                        description: None,
 🟩                                        name: None,
 🟩                                        nullable: false,
 🟩                                        ty: Null,
-⬛️                                    },
-🟥                                ),
+🟩                                    },
 🟩                                ],
 ⬛️                            },
 ⬛️                        ),
@@ -692,6 +695,7 @@ expression: "create_diff::<Enums>()"
 ⬛️                                default_index: None,
 ⬛️                                partial: false,
 ⬛️                                operator: AnyOf,
+⬛️                                variants_names: None,
 ⬛️                                variants_types: [
 ⬛️                                    Schema {
 ⬛️                                        deprecated: None,
@@ -865,6 +869,13 @@ expression: "create_diff::<Enums>()"
 🟥                                partial: true,
 🟩                                partial: false,
 ⬛️                                operator: AnyOf,
+🟥                                variants_names: Some(
+🟥                                    [
+🟥                                        "A",
+🟥                                        "B",
+🟥                                    ],
+🟥                                ),
+🟩                                variants_names: None,
 ⬛️                                variants_types: [
 ⬛️                                    Schema {
 ⬛️                                        deprecated: None,
@@ -897,6 +908,12 @@ expression: "create_diff::<Enums>()"
 🟩                                                default_index: None,
 🟩                                                partial: true,
 🟩                                                operator: AnyOf,
+🟩                                                variants_names: Some(
+🟩                                                    [
+🟩                                                        "A",
+🟩                                                        "B",
+🟩                                                    ],
+🟩                                                ),
 🟩                                                variants_types: [
 🟩                                                    Schema {
 🟩                                                        deprecated: None,
@@ -1065,6 +1082,7 @@ expression: "create_diff::<Enums>()"
 ⬛️                                default_index: None,
 ⬛️                                partial: true,
 ⬛️                                operator: AnyOf,
+⬛️                                variants_names: None,
 ⬛️                                variants_types: [
 ⬛️                                    Schema {
 ⬛️                                        deprecated: None,
@@ -1079,6 +1097,12 @@ expression: "create_diff::<Enums>()"
 ⬛️                                                default_index: None,
 ⬛️                                                partial: true,
 ⬛️                                                operator: AnyOf,
+⬛️                                                variants_names: Some(
+⬛️                                                    [
+⬛️                                                        "A",
+⬛️                                                        "B",
+⬛️                                                    ],
+⬛️                                                ),
 ⬛️                                                variants_types: [
 ⬛️                                                    Schema {
 ⬛️                                                        deprecated: None,

--- a/crates/schematic/tests/snapshots/partialize_test__nested.snap
+++ b/crates/schematic/tests/snapshots/partialize_test__nested.snap
@@ -49,6 +49,7 @@ expression: "create_diff::<Nested>()"
 🟩                                default_index: None,
 🟩                                partial: false,
 🟩                                operator: AnyOf,
+🟩                                variants_names: None,
 🟩                                variants_types: [
 🟩                                    Schema {
 🟩                                        deprecated: None,
@@ -73,6 +74,7 @@ expression: "create_diff::<Nested>()"
 🟩                                                                    default_index: None,
 🟩                                                                    partial: false,
 🟩                                                                    operator: AnyOf,
+🟩                                                                    variants_names: None,
 🟩                                                                    variants_types: [
 🟩                                                                        Schema {
 🟩                                                                            deprecated: None,
@@ -162,6 +164,7 @@ expression: "create_diff::<Nested>()"
 ⬛️                                default_index: None,
 ⬛️                                partial: true,
 ⬛️                                operator: AnyOf,
+⬛️                                variants_names: None,
 ⬛️                                variants_types: [
 ⬛️                                    Schema {
 ⬛️                                        deprecated: None,
@@ -196,6 +199,7 @@ expression: "create_diff::<Nested>()"
 🟩                                                                    default_index: None,
 🟩                                                                    partial: false,
 🟩                                                                    operator: AnyOf,
+🟩                                                                    variants_names: None,
 🟩                                                                    variants_types: [
 🟩                                                                        Schema {
 🟩                                                                            deprecated: None,

--- a/crates/schematic/tests/snapshots/partialize_test__nested_list.snap
+++ b/crates/schematic/tests/snapshots/partialize_test__nested_list.snap
@@ -59,6 +59,7 @@ expression: "create_diff::<NestedList>()"
 🟩                                default_index: None,
 🟩                                partial: false,
 🟩                                operator: AnyOf,
+🟩                                variants_names: None,
 🟩                                variants_types: [
 🟩                                    Schema {
 🟩                                        deprecated: None,
@@ -97,6 +98,7 @@ expression: "create_diff::<NestedList>()"
 🟩                                                                                default_index: None,
 🟩                                                                                partial: false,
 🟩                                                                                operator: AnyOf,
+🟩                                                                                variants_names: None,
 🟩                                                                                variants_types: [
 🟩                                                                                    Schema {
 🟩                                                                                        deprecated: None,
@@ -189,6 +191,7 @@ expression: "create_diff::<NestedList>()"
 ⬛️                                default_index: None,
 ⬛️                                partial: true,
 ⬛️                                operator: AnyOf,
+⬛️                                variants_names: None,
 ⬛️                                variants_types: [
 ⬛️                                    Schema {
 ⬛️                                        deprecated: None,
@@ -231,6 +234,7 @@ expression: "create_diff::<NestedList>()"
 🟩                                                                                default_index: None,
 🟩                                                                                partial: false,
 🟩                                                                                operator: AnyOf,
+🟩                                                                                variants_names: None,
 🟩                                                                                variants_types: [
 🟩                                                                                    Schema {
 🟩                                                                                        deprecated: None,

--- a/crates/schematic/tests/snapshots/partialize_test__nested_map.snap
+++ b/crates/schematic/tests/snapshots/partialize_test__nested_map.snap
@@ -77,6 +77,7 @@ expression: "create_diff::<NestedMap>()"
 🟩                                default_index: None,
 🟩                                partial: false,
 🟩                                operator: AnyOf,
+🟩                                variants_names: None,
 🟩                                variants_types: [
 🟩                                    Schema {
 🟩                                        deprecated: None,
@@ -106,7 +107,7 @@ expression: "create_diff::<NestedMap>()"
 🟩                                                            pattern: None,
 🟩                                                        },
 🟩                                                    ),
-🟩                                                },
+⬛️                                                },
 🟩                                                max_length: None,
 🟩                                                min_length: None,
 🟩                                                required: None,
@@ -133,6 +134,7 @@ expression: "create_diff::<NestedMap>()"
 🟩                                                                                default_index: None,
 🟩                                                                                partial: false,
 🟩                                                                                operator: AnyOf,
+🟩                                                                                variants_names: None,
 🟩                                                                                variants_types: [
 🟩                                                                                    Schema {
 🟩                                                                                        deprecated: None,
@@ -175,7 +177,7 @@ expression: "create_diff::<NestedMap>()"
 🟩                                                            required: None,
 🟩                                                        },
 🟩                                                    ),
-⬛️                                                },
+🟩                                                },
 ⬛️                                            },
 🟥                                            partial: true,
 🟥                                            required: None,
@@ -219,6 +221,7 @@ expression: "create_diff::<NestedMap>()"
 ⬛️                                default_index: None,
 ⬛️                                partial: true,
 ⬛️                                operator: AnyOf,
+⬛️                                variants_names: None,
 ⬛️                                variants_types: [
 ⬛️                                    Schema {
 ⬛️                                        deprecated: None,
@@ -282,6 +285,7 @@ expression: "create_diff::<NestedMap>()"
 🟩                                                                                default_index: None,
 🟩                                                                                partial: false,
 🟩                                                                                operator: AnyOf,
+🟩                                                                                variants_names: None,
 🟩                                                                                variants_types: [
 🟩                                                                                    Schema {
 🟩                                                                                        deprecated: None,

--- a/crates/schematic/tests/snapshots/partialize_test__primitives.snap
+++ b/crates/schematic/tests/snapshots/partialize_test__primitives.snap
@@ -35,6 +35,7 @@ expression: "create_diff::<Primitives>()"
 🟩                                default_index: None,
 🟩                                partial: false,
 🟩                                operator: AnyOf,
+🟩                                variants_names: None,
 🟩                                variants_types: [
 🟩                                    Schema {
 🟩                                        deprecated: None,
@@ -99,6 +100,7 @@ expression: "create_diff::<Primitives>()"
 🟩                                default_index: None,
 🟩                                partial: false,
 🟩                                operator: AnyOf,
+🟩                                variants_names: None,
 🟩                                variants_types: [
 🟩                                    Schema {
 🟩                                        deprecated: None,
@@ -158,6 +160,7 @@ expression: "create_diff::<Primitives>()"
 🟩                                default_index: None,
 🟩                                partial: false,
 🟩                                operator: AnyOf,
+🟩                                variants_names: None,
 🟩                                variants_types: [
 🟩                                    Schema {
 🟩                                        deprecated: None,
@@ -217,6 +220,7 @@ expression: "create_diff::<Primitives>()"
 🟩                                default_index: None,
 🟩                                partial: false,
 🟩                                operator: AnyOf,
+🟩                                variants_names: None,
 🟩                                variants_types: [
 🟩                                    Schema {
 🟩                                        deprecated: None,
@@ -272,6 +276,7 @@ expression: "create_diff::<Primitives>()"
 ⬛️                                default_index: None,
 ⬛️                                partial: false,
 ⬛️                                operator: AnyOf,
+⬛️                                variants_names: None,
 ⬛️                                variants_types: [
 ⬛️                                    Schema {
 ⬛️                                        deprecated: None,
@@ -323,6 +328,7 @@ expression: "create_diff::<Primitives>()"
 ⬛️                                default_index: None,
 ⬛️                                partial: false,
 ⬛️                                operator: AnyOf,
+⬛️                                variants_names: None,
 ⬛️                                variants_types: [
 ⬛️                                    Schema {
 ⬛️                                        deprecated: None,
@@ -377,6 +383,7 @@ expression: "create_diff::<Primitives>()"
 ⬛️                                default_index: None,
 ⬛️                                partial: false,
 ⬛️                                operator: AnyOf,
+⬛️                                variants_names: None,
 ⬛️                                variants_types: [
 ⬛️                                    Schema {
 ⬛️                                        deprecated: None,
@@ -423,6 +430,7 @@ expression: "create_diff::<Primitives>()"
 ⬛️                                default_index: None,
 ⬛️                                partial: false,
 ⬛️                                operator: AnyOf,
+⬛️                                variants_names: None,
 ⬛️                                variants_types: [
 ⬛️                                    Schema {
 ⬛️                                        deprecated: None,

--- a/crates/types/src/unions.rs
+++ b/crates/types/src/unions.rs
@@ -22,6 +22,12 @@ pub struct UnionType {
 
     pub operator: UnionOperator,
 
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub variants_names: Option<Vec<String>>,
+
     pub variants_types: Vec<Box<Schema>>,
 }
 
@@ -59,6 +65,29 @@ impl UnionType {
 
     pub fn has_null(&self) -> bool {
         self.variants_types.iter().any(|schema| schema.ty.is_null())
+    }
+
+    pub fn get_variant_name(&self, index: usize) -> Option<&String> {
+        self.variants_names.as_ref()?.get(index)
+    }
+
+    #[doc(hidden)]
+    pub fn from_named_schemas<I, V>(variants: I, default_index: Option<usize>) -> Self
+    where
+        I: IntoIterator<Item = (String, V)>,
+        V: Into<Schema>,
+    {
+        let (variants_names, variants_types) = variants
+            .into_iter()
+            .map(|(name, inner)| (name, Box::new(inner.into())))
+            .unzip();
+
+        UnionType {
+            default_index,
+            variants_names: Some(variants_names),
+            variants_types,
+            ..UnionType::default()
+        }
     }
 
     #[doc(hidden)]

--- a/crates/types/tests/schema_test.rs
+++ b/crates/types/tests/schema_test.rs
@@ -977,6 +977,32 @@ mod unions {
     }
 
     #[test]
+    fn from_named_schemas_carries_names_by_position() {
+        let ty = UnionType::from_named_schemas(
+            [
+                ("Text".to_owned(), Schema::string(StringType::default())),
+                ("Nothing".to_owned(), Schema::null()),
+            ],
+            Some(1),
+        );
+
+        assert_eq!(ty.default_index, Some(1));
+        assert_eq!(ty.variants_types.len(), 2);
+        assert_eq!(ty.get_variant_name(0), Some(&"Text".to_owned()));
+        assert_eq!(ty.get_variant_name(1), Some(&"Nothing".to_owned()));
+        assert_eq!(ty.get_variant_name(2), None);
+    }
+
+    // A union built by hand has no names, so lookups are simply empty
+    #[test]
+    fn unnamed_union_has_no_variant_names() {
+        let ty = UnionType::new_any(variants());
+
+        assert_eq!(ty.variants_names, None);
+        assert_eq!(ty.get_variant_name(0), None);
+    }
+
+    #[test]
     fn has_null_detects_a_null_variant() {
         assert!(UnionType::new_any(variants()).has_null());
         assert!(


### PR DESCRIPTION
## Summary

Adds `ApiDocsRenderer`, behind a new `renderer_api_docs` feature, which renders a markdown API documentation page per type from a `SchemaGenerator`. It works like the JSON schema renderer: the last type added is the page rendered, and every other type in the generator is a link target.

A page has frontmatter, the type's description, an `## Index` table, then a section per property or variant with tags, its comment, and a table of type information (type, default, values, constraints, aliases, env var). Types referenced from the page are linked inline and listed under `## References`. Structs render properties, unit enums and unions render variants, headed by the variant name.

### Options

- `render_tags`, `render_description`, `render_link`, `render_anchor`: functions that own how tags, descriptions, type links, and index fragments are rendered, for sites with their own components or heading ids.
- `frontmatter`: a map of extra `key: value` entries.
- `enum_format`: render a unit enum's variants as one table instead of sections.
- `include_index`, `index_page`, `exclude_aliases`, `mark_struct_fields_required`.
- `ApiDocsRenderer::generate_all` writes a page for every type into a directory plus an index page listing them.

### Changes outside the renderer

- **`UnionType.variants_names`** (new, optional). A union derived from an enum records each variant's name by position, so a variant can be labeled. A variant's `Schema.name` could not carry this: the generator treats any named schema as a standalone reference, so `List(Vec<String>)` would have become a top-level `List` definition in JSON schema and TypeScript output. Mirrors how `EnumType::from_schemas` moves names out of variant schemas. Hand-built unions carry `None`, and serialization skips it.
- **`SchemaGenerator::add` moves a re-added type to the end.** Without this, adding a type that an earlier type had nested left the old root in place, so a per-type loop silently rendered the wrong page. This reorders two TypeScript snapshots where a fixture re-adds a nested type; content is unchanged.

### Reviewer notes

- Composite types render as a single code span with a separate `References` row, because a markdown link cannot sit inside a code span. Bare references link directly.
- Nullable and flattened fields are not tagged `Required`, unlike the JSON schema renderer's `required` list, since serde accepts a missing `Option` and a flattened field has no key.
- Tags in the enum table mode are plain labels, not routed through `render_tags`, as its block output cannot sit in a table cell.
- Every named type in the generator gets a page, including aliased scalars, since every named type is a link target.

Book page at `book/src/schema/generator/api-docs.md` fills the existing "API documentation" placeholder in the summary. Changelog has an `Unreleased` entry.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo build -p schematic --no-default-features --features renderer_api_docs`
- [x] `cargo test -p schematic_types` on its own
- [x] Regenerated core and partialize snapshots read, not just accepted
- [ ] Tried against a real config crate via `[patch.crates-io]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)